### PR TITLE
chore: remove privacy permissions section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,6 @@ Run project commands from `Apps/Keyty`.
 
 Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.
 
-## Privacy and Permissions
-
-Describe any effect on input capture, local settings, update checks, signing, or macOS permissions. Write `N/A` if there is none.
-
 ## Documentation
 
 - [ ] Updated relevant docs


### PR DESCRIPTION
## Summary

Removed unneeded PR template block

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs

## Release Notes

N/A
