### PR TITLE
fix(release): use project build number in release process

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -196,9 +196,7 @@ def marketing_version
 end
 
 def build_number
-  return validated_build_number(ENV["GITHUB_RUN_NUMBER"], "GITHUB_RUN_NUMBER") if ENV["GITHUB_RUN_NUMBER"]
-
-  current_build_number.next.to_s
+  current_build_number.to_s
 end
 
 def current_build_number


### PR DESCRIPTION
## Summary

Pass build number from Project.swift to Github CI release process

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

## Documentation

- [x] No docs needed

## Release Notes

N/A
