### PR TITLE
fix: prevent status item highlight on launch

### DIFF
--- a/Apps/Keyty/Sources/Keyty/App/Shell/StatusItemController.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Shell/StatusItemController.swift
@@ -43,7 +43,6 @@ final class StatusItemController {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         item.menu = self.menu
         item.button?.image = self.statusItemImage
-        item.button?.cell?.isHighlighted = true
         self.statusItem = item
     }
 


### PR DESCRIPTION
## Summary (https://github.com/esphynox/Keyty/issues/12)

Disable status item highlight on app launch

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

Run project commands from `Apps/Keyty`.

## UI Changes

<img width="439" height="81" alt="Screenshot 2026-07-20 at 19 27 53" src="https://github.com/user-attachments/assets/aee5de22-abd8-49e9-b0fc-dcb8d785993c" />


## Documentation

- [x] No docs needed

## Release Notes

Disable status item highlight on app launch
