### PR TITLE
fix(about): expand tab button hit area

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowView.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowView.swift
@@ -74,6 +74,7 @@ struct AboutWindowView: View {
                                 .foregroundColor(self.viewModel.selectedTab == tab ? Color.Theme.Text.sidebarItemSelected : Color.Theme.Text.sidebarItem)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, Spacing.xs)
+                                .contentShape(Capsule())
                         }
                         .buttonStyle(.plain)
                         .background(self.tabBackground(for: tab))


### PR DESCRIPTION
## Summary (https://github.com/esphynox/Keyty/issues/11)

Fixes the About window tab buttons so the full visible button area is clickable, not only the text label. This improves selection behavior for License, Contributors, and Credits tabs.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] No docs needed

## Release Notes

Expand button hit area in About window