### PR TITLE
fix(about): lazy render credits license text

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowView.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowView.swift
@@ -74,6 +74,7 @@ struct AboutWindowView: View {
                                 .foregroundColor(self.viewModel.selectedTab == tab ? Color.Theme.Text.sidebarItemSelected : Color.Theme.Text.sidebarItem)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, Spacing.xs)
+                                .contentShape(Capsule())
                         }
                         .buttonStyle(.plain)
                         .background(self.tabBackground(for: tab))
@@ -89,7 +90,7 @@ struct AboutWindowView: View {
 
     private var detail: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: Spacing.grid(7)) {
+            LazyVStack(alignment: .leading, spacing: Spacing.grid(7)) {
                 ForEach(self.viewModel.selectedSections) { section in
                     VStack(alignment: .leading, spacing: Spacing.md) {
                         Text(section.title)
@@ -142,10 +143,7 @@ struct AboutWindowView: View {
                         }
 
                         if !section.body.isEmpty {
-                            Text(section.body)
-                                .font(.system(size: 11, weight: .regular, design: .rounded))
-                                .foregroundColor(Color.Theme.Text.secondary)
-                                .fixedSize(horizontal: false, vertical: true)
+                            Self.AboutBodyText(text: section.body)
                         }
                     }
                 }
@@ -170,6 +168,28 @@ struct AboutWindowView: View {
         } else {
             Capsule()
                 .fill(Color.clear)
+        }
+    }
+}
+
+private extension AboutWindowView {
+    struct AboutBodyText: View {
+        let text: String
+
+        var body: some View {
+            LazyVStack(alignment: .leading, spacing: Spacing.none) {
+                ForEach(Array(self.text.components(separatedBy: .newlines).enumerated()), id: \.offset) { _, line in
+                    if line.isEmpty {
+                        Spacer()
+                            .frame(height: Spacing.xs)
+                    } else {
+                        Text(line)
+                            .font(.system(size: 11, weight: .regular, design: .rounded))
+                            .foregroundColor(Color.Theme.Text.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a delay when switching to the About window’s Credits tab by lazily rendering the bundled license text instead of laying out all credit content at once. 

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

## Documentation

- [x] No docs needed

## Release Notes

Fixes a delay when switching to the About window’s Credits tab by lazily rendering the bundled license text instead of laying out all credit content at once. 
