### PR TITLE
fix(settings): clip display preview backgrounds

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane+PreviewCard.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane+PreviewCard.swift
@@ -36,7 +36,6 @@ extension DisplaysSettingsPane {
                                     self.onSelectScreen(screen)
                                 } label: {
                                     self.displayCard(for: screen, size: frame.size)
-                                        .frame(width: frame.width, height: frame.height)
                                         .contentShape(Rectangle())
                                 }
                                 .position(x: frame.midX, y: frame.midY)
@@ -69,6 +68,7 @@ private extension DisplaysSettingsPane.PreviewCard {
                     .shadow(color: Color.Theme.Shadow.displayMarker, radius: 6, y: 2)
             }
         }
+        .frame(width: size.width, height: size.height)
         .clipShape(RoundedRectangle(cornerRadius: self.displayCornerRadius, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: self.displayCornerRadius, style: .continuous)


### PR DESCRIPTION
## Summary (https://github.com/esphynox/Keyty/issues/10)

Fix display settings preview cards by applying their scaled frame before clipping and borders, preventing wallpaper images from bleeding into neighboring display previews.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

Run project commands from `Apps/Keyty`.

## UI Changes

**Before**
<img width="905" height="648" alt="Screenshot 2026-07-20 at 20 06 44" src="https://github.com/user-attachments/assets/7e144e42-fd5b-4575-bdb9-9e269795bfb1" />

**After**
<img width="905" height="648" alt="Screenshot 2026-07-20 at 20 14 44" src="https://github.com/user-attachments/assets/70547be4-5a32-4160-9dfe-cd62c2538595" />

## Documentation

- [x] No docs needed

## Release Notes

Fix display settings preview cards.
