### PR TITLE
feat(settings): add keyboard history section

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
@@ -144,12 +144,6 @@ struct KeyboardSettingsPane: View {
                 title: L10n.KeyboardVisualizer.layoutSectionTitle,
                 subtitle: L10n.KeyboardVisualizer.layoutSectionSubtitle
             ) {
-                SettingsControlRow(title: L10n.KeyboardVisualizer.axisLabel, subtitle: L10n.KeyboardVisualizer.axisSubtitle) {
-                    self.axisPicker
-                }
-
-                Divider()
-
                 SettingsControlRow(title: L10n.KeyboardVisualizer.anchorLabel, subtitle: L10n.KeyboardVisualizer.anchorSubtitle) {
                     Picker("", selection: self.$model.anchor) {
                         ForEach(KeyboardVisualizerAnchor.allCases, id: \.self) { anchor in
@@ -162,6 +156,19 @@ struct KeyboardSettingsPane: View {
 
                 Divider()
 
+                SettingsControlRow(title: L10n.KeyboardVisualizer.sizeLabel, subtitle: L10n.KeyboardVisualizer.sizeSubtitle) {
+                    SettingsSliderControl(
+                        value: self.$model.scale,
+                        range: self.model.scaleRange,
+                        step: self.model.scaleStep
+                    )
+                }
+            }
+
+            SettingsSectionView(
+                title: L10n.KeyboardVisualizer.historySectionTitle,
+                subtitle: L10n.KeyboardVisualizer.historySectionSubtitle
+            ) {
                 SettingsControlRow(title: L10n.KeyboardVisualizer.maxCountLabel, subtitle: L10n.KeyboardVisualizer.maxCountSubtitle) {
                     HStack(spacing: Spacing.sm) {
                         Text("\(self.model.maxCount)")
@@ -176,12 +183,8 @@ struct KeyboardSettingsPane: View {
 
                 Divider()
 
-                SettingsControlRow(title: L10n.KeyboardVisualizer.sizeLabel, subtitle: L10n.KeyboardVisualizer.sizeSubtitle) {
-                    SettingsSliderControl(
-                        value: self.$model.scale,
-                        range: self.model.scaleRange,
-                        step: self.model.scaleStep
-                    )
+                SettingsControlRow(title: L10n.KeyboardVisualizer.axisLabel, subtitle: L10n.KeyboardVisualizer.axisSubtitle) {
+                    self.axisPicker
                 }
             }
 

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -81,7 +81,9 @@
 "keyboard_visualizer.theme_section_title" = "Theme";
 "keyboard_visualizer.theme_section_subtitle" = "Give each key type its own color palette.";
 "keyboard_visualizer.layout_section_title" = "Layout";
-"keyboard_visualizer.layout_section_subtitle" = "Control stack direction, screen anchor, and how much space the overlay occupies.";
+"keyboard_visualizer.layout_section_subtitle" = "Control screen anchor and how much space the overlay occupies.";
+"keyboard_visualizer.history_section_title" = "History";
+"keyboard_visualizer.history_section_subtitle" = "Control how many keycaps remain visible and how consecutive groups stack.";
 "keyboard_visualizer.timing_section_title" = "Timing";
 "keyboard_visualizer.timing_section_subtitle" = "Balance readability and responsiveness by controlling how long keys remain visible and how quickly they fade.";
 "keyboard_visualizer.filter_section_title" = "Filter";


### PR DESCRIPTION
## Summary

Moved keyboard history-related controls into their own History section in Keyboard settings.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

Before
<img width="905" height="648" alt="Screenshot 2026-07-21 at 12 35 30" src="https://github.com/user-attachments/assets/667e3751-4d89-41ae-b96f-5d743b7fdcfb" />

After
<img width="905" height="648" alt="Screenshot 2026-07-21 at 12 35 02" src="https://github.com/user-attachments/assets/c4b6ecad-03cb-4156-a305-1fbc5293f522" />

## Documentation

- [x] No docs needed

## Release Notes

Moved keyboard history-related controls into their own History section in Keyboard settings.
