### PR TITLE
fix(settings): update default pointer ring size

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Mouse/PointerRing/PointerRingSettingsKeys.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Mouse/PointerRing/PointerRingSettingsKeys.swift
@@ -19,8 +19,8 @@ enum PointerRingSettingsKeys {
     static let defaultIsEnabled = false
     static let defaultAlwaysVisible = false
     static let defaultColor = automaticVisualizerColor.hexString
-    static let defaultSize = CGFloat(44)
-    static let defaultThickness = CGFloat(2)
+    static let defaultSize = CGFloat(75)
+    static let defaultThickness = CGFloat(5)
     static let defaultShape = PointerRingShape.circle
     static let sizeRange: ClosedRange<CGFloat> = 24...96
     static let thicknessRange: ClosedRange<CGFloat> = 1...12


### PR DESCRIPTION
## Summary

Set the default pointer ring size to 75 and default thickness to 5.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

N/A

## Documentation

- [x] No docs needed

## Release Notes

Set the default pointer ring size to 75 and default thickness to 5.
