### PR TITLE
fix(shortcuts): keep toggle available while listening is disabled

### DIFF
--- a/Apps/Keyty/Sources/Keyty/App/Composition/AppServiceContainer.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Composition/AppServiceContainer.swift
@@ -39,12 +39,15 @@ final class AppServiceContainer {
         self.keyboardVisualizer = keyboardVisualizer
         self.shortcutManager = shortcutManager
         self.presenceManager = presenceManager
-        self.captureController = CaptureController(
-            shortcutManager: shortcutManager,
+        let captureController = CaptureController(
             presenceManager: presenceManager,
             pointerVisualizersManager: pointerVisualizersManager,
             keyboardVisualizer: keyboardVisualizer,
             permissionsService: permissionsService
         )
+        shortcutManager.onToggleCapturingShortcut = { [weak captureController] in
+            captureController?.toggleCapturing()
+        }
+        self.captureController = captureController
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
+++ b/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
@@ -7,7 +7,6 @@
 //
 
 import Cocoa
-import ShortcutRecorder
 
 final class CaptureController {
     var isCapturing: Bool { self.state == .capturing }
@@ -20,7 +19,6 @@ final class CaptureController {
 
     private let eventTap = EventTap()
     private let eventProcessor = EventProcessor()
-    private let shortcutManager: ShortcutManager
     private let presenceManager: PresenceManager
     private let pointerVisualizersManager: PointerVisualizersManager
     private let keyboardVisualizer: KeyboardVisualizer
@@ -28,13 +26,11 @@ final class CaptureController {
     private var permissionObservationToken: PermissionObservationToken?
 
     init(
-        shortcutManager: ShortcutManager,
         presenceManager: PresenceManager,
         pointerVisualizersManager: PointerVisualizersManager,
         keyboardVisualizer: KeyboardVisualizer,
         permissionsService: any PermissionsService
     ) {
-        self.shortcutManager = shortcutManager
         self.presenceManager = presenceManager
         self.pointerVisualizersManager = pointerVisualizersManager
         self.keyboardVisualizer = keyboardVisualizer
@@ -191,14 +187,6 @@ extension CaptureController: EventTapDelegate {
     }
 
     func eventTap(_ tap: EventTap, noteKeystroke keystroke: StandardKeyEvent) {
-        if keystroke.type == .keyDown, let shortcut = self.shortcutManager.toggleCapturingShortcut {
-            let relevant: NSEvent.ModifierFlags = [.control, .command, .shift, .option]
-            if keystroke.keyCode == shortcut.keyCode.rawValue &&
-               keystroke.modifierFlags.intersection(relevant) == shortcut.modifierFlags.intersection(relevant) {
-                self.toggleCapturing()
-                return
-            }
-        }
         guard self.isCapturing else { return }
         self.eventProcessor.noteKeystroke(keystroke)
     }

--- a/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutManager.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutManager.swift
@@ -9,12 +9,22 @@
 import Cocoa
 import ShortcutRecorder
 
+protocol GlobalShortcutMonitoring: AnyObject {
+    func addAction(_ action: ShortcutAction, forKeyEvent keyEvent: KeyEventType)
+    func removeAction(_ action: ShortcutAction)
+}
+
+extension GlobalShortcutMonitor: GlobalShortcutMonitoring {}
+
 final class ShortcutManager: NSObject {
     weak var statusShortcutItem: NSMenuItem?
     weak var dockShortcutItem: NSMenuItem?
+    var onToggleCapturingShortcut: (() -> Void)?
 
     private let settings: any ShortcutSettingsProtocol
+    private let globalShortcutMonitor: any GlobalShortcutMonitoring
     private var _toggleCapturingShortcut: Shortcut?
+    private var toggleCapturingShortcutAction: ShortcutAction?
 
     var toggleCapturingShortcut: Shortcut? {
         get {
@@ -26,12 +36,24 @@ final class ShortcutManager: NSObject {
         set {
             self._toggleCapturingShortcut = self.persistShortcut(newValue)
             self.refreshMenuItems()
+            self.refreshGlobalShortcut()
         }
     }
 
-    init(settings: any ShortcutSettingsProtocol = ShortcutSettings()) {
+    init(
+        settings: any ShortcutSettingsProtocol = ShortcutSettings(),
+        globalShortcutMonitor: any GlobalShortcutMonitoring = GlobalShortcutMonitor.shared
+    ) {
         self.settings = settings
+        self.globalShortcutMonitor = globalShortcutMonitor
         super.init()
+        self.refreshGlobalShortcut()
+    }
+
+    deinit {
+        if let action = self.toggleCapturingShortcutAction {
+            self.globalShortcutMonitor.removeAction(action)
+        }
     }
 
     func configureToggleShortcutRecorder(_ recorder: RecorderControl) {
@@ -80,6 +102,24 @@ final class ShortcutManager: NSObject {
         } catch {
             return self.shortcutFromSettings()
         }
+    }
+
+    private func refreshGlobalShortcut() {
+        if let action = self.toggleCapturingShortcutAction {
+            self.globalShortcutMonitor.removeAction(action)
+        }
+
+        guard let shortcut = self.toggleCapturingShortcut else {
+            self.toggleCapturingShortcutAction = nil
+            return
+        }
+
+        let action = ShortcutAction(shortcut: shortcut) { [weak self] _ in
+            self?.onToggleCapturingShortcut?()
+            return true
+        }
+        self.toggleCapturingShortcutAction = action
+        self.globalShortcutMonitor.addAction(action, forKeyEvent: .down)
     }
 }
 

--- a/Apps/Keyty/Tests/KeytyTests/Services/Shortcuts/ShortcutManagerTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/Shortcuts/ShortcutManagerTests.swift
@@ -13,6 +13,7 @@ import ShortcutRecorder
 final class ShortcutManagerTests: XCTestCase {
     private var store: InMemoryKeyValueStore!
     private var settings: ShortcutSettings!
+    private var globalShortcutMonitor: FakeGlobalShortcutMonitor!
     private var manager: ShortcutManager!
 
     override func setUp() {
@@ -20,11 +21,13 @@ final class ShortcutManagerTests: XCTestCase {
         store = InMemoryKeyValueStore()
         settings = ShortcutSettings(store: store)
         settings.registerDefaults()
-        manager = ShortcutManager(settings: settings)
+        globalShortcutMonitor = FakeGlobalShortcutMonitor()
+        manager = ShortcutManager(settings: settings, globalShortcutMonitor: globalShortcutMonitor)
     }
 
     override func tearDown() {
         manager = nil
+        globalShortcutMonitor = nil
         settings = nil
         store = nil
         super.tearDown()
@@ -71,7 +74,7 @@ final class ShortcutManagerTests: XCTestCase {
         )
         store.set(try ShortcutArchiver.data(for: shortcut), forKey: ShortcutSettings.capturingHotKeyKey)
 
-        manager = ShortcutManager(settings: settings)
+        manager = ShortcutManager(settings: settings, globalShortcutMonitor: globalShortcutMonitor)
 
         XCTAssertEqual(manager.toggleCapturingShortcut, shortcut)
     }
@@ -79,8 +82,65 @@ final class ShortcutManagerTests: XCTestCase {
     func testFallsBackToDefaultShortcutWhenStoredDataIsInvalid() {
         store.set(Data([0x00, 0x01, 0x02]), forKey: ShortcutSettings.capturingHotKeyKey)
 
-        manager = ShortcutManager(settings: settings)
+        manager = ShortcutManager(settings: settings, globalShortcutMonitor: globalShortcutMonitor)
 
         XCTAssertEqual(manager.toggleCapturingShortcut, ShortcutArchiver.defaultShortcut())
+    }
+
+    func testRegistersGlobalShortcutAtStartup() {
+        XCTAssertEqual(globalShortcutMonitor.addedActions.count, 1)
+        XCTAssertEqual(globalShortcutMonitor.addedActions.first?.shortcut, ShortcutArchiver.defaultShortcut())
+        XCTAssertEqual(globalShortcutMonitor.addedKeyEvents, [.down])
+    }
+
+    func testUpdatesRegisteredGlobalShortcutWhenShortcutChanges() {
+        let shortcut = Shortcut(
+            code: .ansiA,
+            modifierFlags: [.command, .option],
+            characters: nil,
+            charactersIgnoringModifiers: nil
+        )
+
+        manager.toggleCapturingShortcut = shortcut
+
+        XCTAssertEqual(globalShortcutMonitor.removedActions.count, 1)
+        XCTAssertEqual(globalShortcutMonitor.addedActions.count, 2)
+        XCTAssertEqual(globalShortcutMonitor.addedActions.last?.shortcut, shortcut)
+    }
+
+    func testGlobalShortcutActionTogglesCapturing() {
+        var toggleCount = 0
+        manager.onToggleCapturingShortcut = {
+            toggleCount += 1
+        }
+
+        globalShortcutMonitor.performLastAction()
+
+        XCTAssertEqual(toggleCount, 1)
+    }
+
+    func testUnregistersGlobalShortcutOnDeinit() {
+        manager = nil
+
+        XCTAssertEqual(globalShortcutMonitor.removedActions.count, 1)
+    }
+}
+
+private final class FakeGlobalShortcutMonitor: GlobalShortcutMonitoring {
+    private(set) var addedActions: [ShortcutAction] = []
+    private(set) var addedKeyEvents: [KeyEventType] = []
+    private(set) var removedActions: [ShortcutAction] = []
+
+    func addAction(_ action: ShortcutAction, forKeyEvent keyEvent: KeyEventType) {
+        self.addedActions.append(action)
+        self.addedKeyEvents.append(keyEvent)
+    }
+
+    func removeAction(_ action: ShortcutAction) {
+        self.removedActions.append(action)
+    }
+
+    func performLastAction() {
+        self.addedActions.last?.perform(onTarget: nil)
     }
 }


### PR DESCRIPTION
## Summary

Registers the capture toggle shortcut with `ShortcutRecorder`'s global hotkey monitor instead of relying on Keyty’s capture event tap. This keeps the shortcut available after listening is disabled, allowing it to re-enable capture from anywhere.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] No docs needed

## Release Notes

Fixes a bug where the global shortcut could disable listening but could not enable it again.
