### PR TITLE
refactor(shortcuts): improve manager structure and validation

### DIFF
--- a/Apps/Keyty/Sources/Keyty/App/Composition/AppDependencies.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Composition/AppDependencies.swift
@@ -36,16 +36,13 @@ final class AppDependencies {
         self.settings = AppSettingsContainer(store: keyValueStore)
         self.services = AppServiceContainer(
             settings: self.settings,
-            dockItemController: dockItemController
+            dockItemController: dockItemController,
+            statusShortcutItem: statusShortcutItem
         )
         self.ui = AppUIContainer(
             settings: self.settings,
             services: self.services,
             updater: updater
         )
-
-        self.services.shortcutManager.statusShortcutItem = statusShortcutItem
-        self.services.shortcutManager.dockShortcutItem = dockItemController.shortcutItem
-        self.services.shortcutManager.refreshMenuItems()
     }
 }

--- a/Apps/Keyty/Sources/Keyty/App/Composition/AppServiceContainer.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Composition/AppServiceContainer.swift
@@ -19,13 +19,13 @@ final class AppServiceContainer {
 
     init(
         settings: AppSettingsContainer,
-        dockItemController: DockItemController
+        dockItemController: DockItemController,
+        statusShortcutItem: NSMenuItem
     ) {
         let pointerVisualizersManager = PointerVisualizersManager(
             pointerRingSettings: settings.pointerRingSettings,
             pointerIconSettings: settings.pointerIconSettings
         )
-        let shortcutManager = ShortcutManager(settings: settings.shortcutSettings)
         let presenceManager = PresenceManager(
             dockItemController: dockItemController,
             settings: settings.presenceSettings
@@ -33,21 +33,28 @@ final class AppServiceContainer {
         let keyboardVisualizer = KeyboardVisualizer(store: settings.store)
         keyboardVisualizer.activate()
         let permissionsService = SystemPermissionsService()
-
-        self.permissionsService = permissionsService
-        self.pointerVisualizersManager = pointerVisualizersManager
-        self.keyboardVisualizer = keyboardVisualizer
-        self.shortcutManager = shortcutManager
-        self.presenceManager = presenceManager
         let captureController = CaptureController(
             presenceManager: presenceManager,
             pointerVisualizersManager: pointerVisualizersManager,
             keyboardVisualizer: keyboardVisualizer,
             permissionsService: permissionsService
         )
-        shortcutManager.onToggleCapturingShortcut = { [weak captureController] in
-            captureController?.toggleCapturing()
-        }
+        let shortcutManager = ShortcutManager(
+            settings: settings.shortcutSettings,
+            menuItemPresenter: ShortcutMenuItemPresenter(
+                statusShortcutItem: statusShortcutItem,
+                dockShortcutItem: dockItemController.shortcutItem
+            ),
+            onToggleCapturingShortcut: { [weak captureController] in
+                captureController?.toggleCapturing()
+            }
+        )
+
+        self.permissionsService = permissionsService
+        self.pointerVisualizersManager = pointerVisualizersManager
+        self.keyboardVisualizer = keyboardVisualizer
+        self.shortcutManager = shortcutManager
+        self.presenceManager = presenceManager
         self.captureController = captureController
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/General/GeneralSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/General/GeneralSettingsPane.swift
@@ -53,8 +53,19 @@ struct GeneralSettingsPane: View {
                     title: L10n.General.toggleCapturingLabel,
                     subtitle: L10n.General.toggleCapturingSubtitle
                 ) {
-                    ShortcutRecorderView(shortcutManager: model.shortcutManager)
-                        .frame(Size.Settings.recorder)
+                    VStack(alignment: .trailing, spacing: Spacing.xxs) {
+                        ShortcutRecorderView(shortcutManager: model.shortcutManager)
+                            .frame(Size.Settings.recorder)
+
+                        if let validationMessage = model.shortcutValidationMessage {
+                            Text(validationMessage)
+                                .font(Typography.Settings.rowSubtitle)
+                                .foregroundColor(Color.Theme.State.danger)
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
                 }
             }
         }

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/General/GeneralSettingsPaneViewModel.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/General/GeneralSettingsPaneViewModel.swift
@@ -22,12 +22,18 @@ final class GeneralSettingsPaneViewModel: ObservableObject {
         didSet { self.appSettings.visibleAtLaunch = self.visibleAtLaunch }
     }
 
+    @Published var shortcutValidationMessage: String?
+
     init(shortcutManager: ShortcutManager, presenceManager: PresenceManager, appSettings: any AppSettingsProtocol) {
         self.shortcutManager = shortcutManager
         self.presenceManager = presenceManager
         self.appSettings = appSettings
 
-        self.displayIconLocation = presenceManager.displayIconLocationRawValue
-        self.visibleAtLaunch = appSettings.visibleAtLaunch
+        self.displayIconLocation = self.presenceManager.displayIconLocationRawValue
+        self.visibleAtLaunch = self.appSettings.visibleAtLaunch
+        self.shortcutValidationMessage = self.shortcutManager.shortcutValidationMessage
+        self.shortcutManager.onShortcutValidationMessageChanged = { [weak self] message in
+            self?.shortcutValidationMessage = message
+        }
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -68,6 +68,7 @@
 "general.display_icon.menu_bar_and_dock" = "Menu Bar and Dock";
 "general.toggle_capturing_label" = "Toggle capturing";
 "general.toggle_capturing_subtitle" = "Global shortcut used to start or stop capturing from anywhere.";
+"general.shortcut_validation_fallback" = "This shortcut cannot be used.";
 "general.start_capturing" = "Enable";
 "general.stop_capturing" = "Disable";
 "general.show_settings_at_launch" = "Show settings at launch";

--- a/Apps/Keyty/Sources/Keyty/Services/Shortcuts/GlobalShortcutMonitoring.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Shortcuts/GlobalShortcutMonitoring.swift
@@ -1,0 +1,20 @@
+//
+//  GlobalShortcutMonitoring.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import ShortcutRecorder
+
+/// Registers and removes app-level global shortcut actions.
+protocol GlobalShortcutMonitoring: AnyObject {
+    /// Registers an action for the key event represented by a validated shortcut.
+    func addAction(_ action: ShortcutAction, forKeyEvent keyEvent: KeyEventType)
+
+    /// Removes a previously registered action from the global shortcut monitor.
+    func removeAction(_ action: ShortcutAction)
+}
+
+extension GlobalShortcutMonitor: GlobalShortcutMonitoring {}

--- a/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutManager.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutManager.swift
@@ -9,23 +9,28 @@
 import Cocoa
 import ShortcutRecorder
 
-protocol GlobalShortcutMonitoring: AnyObject {
-    func addAction(_ action: ShortcutAction, forKeyEvent keyEvent: KeyEventType)
-    func removeAction(_ action: ShortcutAction)
-}
-
-extension GlobalShortcutMonitor: GlobalShortcutMonitoring {}
-
+/// Manages the toggle-capturing shortcut across persistence, menu presentation, recorder validation, and global registration.
 final class ShortcutManager: NSObject {
-    weak var statusShortcutItem: NSMenuItem?
-    weak var dockShortcutItem: NSMenuItem?
-    var onToggleCapturingShortcut: (() -> Void)?
+    /// The latest shortcut validation error shown in settings, or `nil` when the current shortcut is valid.
+    private(set) var shortcutValidationMessage: String? {
+        didSet {
+            guard oldValue != self.shortcutValidationMessage else { return }
+            self.onShortcutValidationMessageChanged?(self.shortcutValidationMessage)
+        }
+    }
+
+    /// Called when `shortcutValidationMessage` changes.
+    var onShortcutValidationMessageChanged: ((String?) -> Void)?
 
     private let settings: any ShortcutSettingsProtocol
     private let globalShortcutMonitor: any GlobalShortcutMonitoring
+    private let shortcutValidator: any ShortcutValidating
+    private let menuItemPresenter: any ShortcutMenuItemPresenting
+    private let onToggleCapturingShortcut: () -> Void
     private var _toggleCapturingShortcut: Shortcut?
     private var toggleCapturingShortcutAction: ShortcutAction?
 
+    /// The shortcut assigned to toggle capturing, loaded from settings on first read and persisted on update.
     var toggleCapturingShortcut: Shortcut? {
         get {
             if self._toggleCapturingShortcut == nil {
@@ -34,20 +39,25 @@ final class ShortcutManager: NSObject {
             return self._toggleCapturingShortcut
         }
         set {
-            self._toggleCapturingShortcut = self.persistShortcut(newValue)
-            self.refreshMenuItems()
-            self.refreshGlobalShortcut()
+            self.setToggleCapturingShortcut(newValue)
         }
     }
 
     init(
         settings: any ShortcutSettingsProtocol = ShortcutSettings(),
-        globalShortcutMonitor: any GlobalShortcutMonitoring = GlobalShortcutMonitor.shared
+        globalShortcutMonitor: any GlobalShortcutMonitoring = GlobalShortcutMonitor.shared,
+        shortcutValidator: any ShortcutValidating = ShortcutValidator(),
+        menuItemPresenter: any ShortcutMenuItemPresenting,
+        onToggleCapturingShortcut: @escaping () -> Void
     ) {
         self.settings = settings
         self.globalShortcutMonitor = globalShortcutMonitor
+        self.shortcutValidator = shortcutValidator
+        self.menuItemPresenter = menuItemPresenter
+        self.onToggleCapturingShortcut = onToggleCapturingShortcut
         super.init()
-        self.refreshGlobalShortcut()
+        self.refreshMenuItems()
+        self.refreshGlobalShortcutIfNeeded()
     }
 
     deinit {
@@ -62,27 +72,12 @@ final class ShortcutManager: NSObject {
     }
 
     func refreshMenuItems() {
-        if let shortcut = self.toggleCapturingShortcut {
-            let keyEquivalent = SymbolicKeyCodeTransformer.shared.transformedValue(NSNumber(value: shortcut.keyCode.rawValue)) ?? ""
-            self.setKeyEquavalent(keyEquivalent)
-            self.setKeyEquivalentModifierMask(shortcut.modifierFlags)
-        } else {
-            self.setKeyEquavalent("")
-            self.setKeyEquivalentModifierMask([])
-        }
+        self.menuItemPresenter.displayShortcut(self.toggleCapturingShortcut)
     }
-    
-    private func setKeyEquavalent(_ keyEquivalent: String) {
-        self.statusShortcutItem?.keyEquivalent = keyEquivalent
-        self.dockShortcutItem?.keyEquivalent = keyEquivalent
-    }
-    
-    private func setKeyEquivalentModifierMask(_ modifierFlags: NSEvent.ModifierFlags) {
-        self.statusShortcutItem?.keyEquivalentModifierMask = modifierFlags
-        self.dockShortcutItem?.keyEquivalentModifierMask = modifierFlags
-    }
+}
 
-    // MARK: - Private
+// MARK: - Logic
+private extension ShortcutManager {
     private func shortcutFromSettings() -> Shortcut? {
         guard let data = self.settings.capturingHotKeyData else {
             return ShortcutArchiver.defaultShortcut()
@@ -104,7 +99,27 @@ final class ShortcutManager: NSObject {
         }
     }
 
-    private func refreshGlobalShortcut() {
+    private func setToggleCapturingShortcut(_ shortcut: Shortcut?) {
+        if let shortcut, let validationMessage = self.shortcutValidator.validationMessage(for: shortcut) {
+            self.shortcutValidationMessage = validationMessage
+            return
+        }
+
+        let currentShortcut = self.toggleCapturingShortcut
+        let persistedShortcut = self.persistShortcut(shortcut)
+        self.shortcutValidationMessage = nil
+
+        guard currentShortcut != persistedShortcut else {
+            self._toggleCapturingShortcut = persistedShortcut
+            return
+        }
+
+        self._toggleCapturingShortcut = persistedShortcut
+        self.refreshMenuItems()
+        self.refreshGlobalShortcutIfNeeded()
+    }
+
+    private func refreshGlobalShortcutIfNeeded() {
         if let action = self.toggleCapturingShortcutAction {
             self.globalShortcutMonitor.removeAction(action)
         }
@@ -114,8 +129,15 @@ final class ShortcutManager: NSObject {
             return
         }
 
+        if let validationMessage = self.shortcutValidator.validationMessage(for: shortcut) {
+            self.shortcutValidationMessage = validationMessage
+            self.toggleCapturingShortcutAction = nil
+            return
+        }
+
+        self.shortcutValidationMessage = nil
         let action = ShortcutAction(shortcut: shortcut) { [weak self] _ in
-            self?.onToggleCapturingShortcut?()
+            self?.onToggleCapturingShortcut()
             return true
         }
         self.toggleCapturingShortcutAction = action
@@ -125,6 +147,17 @@ final class ShortcutManager: NSObject {
 
 // MARK: - SRRecorderControlDelegate
 extension ShortcutManager: RecorderControlDelegate {
+    @objc(recorderControl:canRecordShortcut:)
+    func recorderControl(_ control: RecorderControl, canRecord shortcut: Shortcut) -> Bool {
+        if let validationMessage = self.shortcutValidator.validationMessage(for: shortcut) {
+            self.shortcutValidationMessage = validationMessage
+            return false
+        }
+
+        self.shortcutValidationMessage = nil
+        return true
+    }
+
     @objc func recorderControlDidEndRecording(_ control: RecorderControl) {
         guard let newShortcut = control.objectValue else {
             self.toggleCapturingShortcut = nil

--- a/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutMenuItemPresenter.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutMenuItemPresenter.swift
@@ -1,0 +1,54 @@
+//
+//  ShortcutMenuItemPresenter.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Cocoa
+import ShortcutRecorder
+
+/// Displays the configured shortcut in menu items that expose the toggle command.
+protocol ShortcutMenuItemPresenting: AnyObject {
+    /// Shows the shortcut in attached menu items, or clears them when `shortcut` is `nil`.
+    func displayShortcut(_ shortcut: Shortcut?)
+}
+
+/// Updates status bar and dock menu items to display the currently assigned toggle shortcut.
+final class ShortcutMenuItemPresenter {
+    private weak var statusShortcutItem: NSMenuItem?
+    private weak var dockShortcutItem: NSMenuItem?
+
+    init(statusShortcutItem: NSMenuItem, dockShortcutItem: NSMenuItem) {
+        self.statusShortcutItem = statusShortcutItem
+        self.dockShortcutItem = dockShortcutItem
+    }
+}
+
+// MARK: - Logic
+private extension ShortcutMenuItemPresenter {
+    private func setKeyEquivalent(_ keyEquivalent: String) {
+        self.statusShortcutItem?.keyEquivalent = keyEquivalent
+        self.dockShortcutItem?.keyEquivalent = keyEquivalent
+    }
+
+    private func setKeyEquivalentModifierMask(_ modifierFlags: NSEvent.ModifierFlags) {
+        self.statusShortcutItem?.keyEquivalentModifierMask = modifierFlags
+        self.dockShortcutItem?.keyEquivalentModifierMask = modifierFlags
+    }
+}
+
+// MARK: - ShortcutMenuItemPresenting
+extension ShortcutMenuItemPresenter: ShortcutMenuItemPresenting {
+    func displayShortcut(_ shortcut: Shortcut?) {
+        if let shortcut {
+            let keyEquivalent = SymbolicKeyCodeTransformer.shared.transformedValue(NSNumber(value: shortcut.keyCode.rawValue)) ?? ""
+            self.setKeyEquivalent(keyEquivalent)
+            self.setKeyEquivalentModifierMask(shortcut.modifierFlags)
+        } else {
+            self.setKeyEquivalent("")
+            self.setKeyEquivalentModifierMask([])
+        }
+    }
+}

--- a/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutValidating.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutValidating.swift
@@ -1,0 +1,30 @@
+//
+//  ShortcutValidating.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Foundation
+import ShortcutRecorder
+
+/// Validates shortcuts before they are persisted or registered as global hotkeys.
+protocol ShortcutValidating: AnyObject {
+    /// Returns a localized validation failure message, or `nil` when the shortcut is valid.
+    func validationMessage(for shortcut: Shortcut) -> String?
+}
+
+extension ShortcutValidator: ShortcutValidating {
+    func validationMessage(for shortcut: Shortcut) -> String? {
+        do {
+            try self.validate(shortcut: shortcut)
+            return nil
+        } catch {
+            return error.localizedDescription.isEmpty ? NSLocalizedString(
+                "general.shortcut_validation_fallback",
+                comment: "Fallback shortcut validation failure message"
+            ) : error.localizedDescription
+        }
+    }
+}

--- a/Apps/Keyty/Tests/KeytyTests/Services/Shortcuts/ShortcutManagerTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/Shortcuts/ShortcutManagerTests.swift
@@ -14,28 +14,37 @@ final class ShortcutManagerTests: XCTestCase {
     private var store: InMemoryKeyValueStore!
     private var settings: ShortcutSettings!
     private var globalShortcutMonitor: FakeGlobalShortcutMonitor!
+    private var shortcutValidator: FakeShortcutValidator!
+    private var menuItemPresenter: FakeShortcutMenuItemPresenter!
     private var manager: ShortcutManager!
+    private var toggleCount: Int!
 
     override func setUp() {
         super.setUp()
-        store = InMemoryKeyValueStore()
-        settings = ShortcutSettings(store: store)
-        settings.registerDefaults()
-        globalShortcutMonitor = FakeGlobalShortcutMonitor()
-        manager = ShortcutManager(settings: settings, globalShortcutMonitor: globalShortcutMonitor)
+        self.store = InMemoryKeyValueStore()
+        self.settings = ShortcutSettings(store: self.store)
+        self.settings.registerDefaults()
+        self.globalShortcutMonitor = FakeGlobalShortcutMonitor()
+        self.shortcutValidator = FakeShortcutValidator()
+        self.menuItemPresenter = FakeShortcutMenuItemPresenter()
+        self.toggleCount = 0
+        self.manager = self.makeManager()
     }
 
     override func tearDown() {
-        manager = nil
-        globalShortcutMonitor = nil
-        settings = nil
-        store = nil
+        self.manager = nil
+        self.toggleCount = nil
+        self.menuItemPresenter = nil
+        self.shortcutValidator = nil
+        self.globalShortcutMonitor = nil
+        self.settings = nil
+        self.store = nil
         super.tearDown()
     }
 
     func testRegistersDefaultShortcutData() {
         XCTAssertEqual(
-            store.data(forKey: ShortcutSettings.capturingHotKeyKey),
+            self.store.data(forKey: ShortcutSettings.capturingHotKeyKey),
             ShortcutArchiver.defaultData()
         )
     }
@@ -48,19 +57,19 @@ final class ShortcutManagerTests: XCTestCase {
             charactersIgnoringModifiers: nil
         )
 
-        manager.toggleCapturingShortcut = shortcut
+        self.manager.toggleCapturingShortcut = shortcut
 
         XCTAssertEqual(
-            store.data(forKey: ShortcutSettings.capturingHotKeyKey),
+            self.store.data(forKey: ShortcutSettings.capturingHotKeyKey),
             try ShortcutArchiver.data(for: shortcut)
         )
     }
 
     func testClearingShortcutRevertsToDefaultData() {
-        manager.toggleCapturingShortcut = nil
+        self.manager.toggleCapturingShortcut = nil
 
         XCTAssertEqual(
-            store.data(forKey: ShortcutSettings.capturingHotKeyKey),
+            self.store.data(forKey: ShortcutSettings.capturingHotKeyKey),
             ShortcutArchiver.defaultData()
         )
     }
@@ -72,25 +81,25 @@ final class ShortcutManagerTests: XCTestCase {
             characters: nil,
             charactersIgnoringModifiers: nil
         )
-        store.set(try ShortcutArchiver.data(for: shortcut), forKey: ShortcutSettings.capturingHotKeyKey)
+        self.store.set(try ShortcutArchiver.data(for: shortcut), forKey: ShortcutSettings.capturingHotKeyKey)
 
-        manager = ShortcutManager(settings: settings, globalShortcutMonitor: globalShortcutMonitor)
+        self.manager = self.makeManager()
 
-        XCTAssertEqual(manager.toggleCapturingShortcut, shortcut)
+        XCTAssertEqual(self.manager.toggleCapturingShortcut, shortcut)
     }
 
     func testFallsBackToDefaultShortcutWhenStoredDataIsInvalid() {
-        store.set(Data([0x00, 0x01, 0x02]), forKey: ShortcutSettings.capturingHotKeyKey)
+        self.store.set(Data([0x00, 0x01, 0x02]), forKey: ShortcutSettings.capturingHotKeyKey)
 
-        manager = ShortcutManager(settings: settings, globalShortcutMonitor: globalShortcutMonitor)
+        self.manager = self.makeManager()
 
-        XCTAssertEqual(manager.toggleCapturingShortcut, ShortcutArchiver.defaultShortcut())
+        XCTAssertEqual(self.manager.toggleCapturingShortcut, ShortcutArchiver.defaultShortcut())
     }
 
     func testRegistersGlobalShortcutAtStartup() {
-        XCTAssertEqual(globalShortcutMonitor.addedActions.count, 1)
-        XCTAssertEqual(globalShortcutMonitor.addedActions.first?.shortcut, ShortcutArchiver.defaultShortcut())
-        XCTAssertEqual(globalShortcutMonitor.addedKeyEvents, [.down])
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.count, 1)
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.first?.shortcut, ShortcutArchiver.defaultShortcut())
+        XCTAssertEqual(self.globalShortcutMonitor.addedKeyEvents, [.down])
     }
 
     func testUpdatesRegisteredGlobalShortcutWhenShortcutChanges() {
@@ -101,28 +110,97 @@ final class ShortcutManagerTests: XCTestCase {
             charactersIgnoringModifiers: nil
         )
 
-        manager.toggleCapturingShortcut = shortcut
+        self.manager.toggleCapturingShortcut = shortcut
 
-        XCTAssertEqual(globalShortcutMonitor.removedActions.count, 1)
-        XCTAssertEqual(globalShortcutMonitor.addedActions.count, 2)
-        XCTAssertEqual(globalShortcutMonitor.addedActions.last?.shortcut, shortcut)
+        XCTAssertEqual(self.globalShortcutMonitor.removedActions.count, 1)
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.count, 2)
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.last?.shortcut, shortcut)
+    }
+
+    func testDoesNotUpdateRegisteredGlobalShortcutWhenShortcutIsUnchanged() {
+        let shortcut = ShortcutArchiver.defaultShortcut()
+
+        self.manager.toggleCapturingShortcut = shortcut
+
+        XCTAssertEqual(self.globalShortcutMonitor.removedActions.count, 0)
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.count, 1)
     }
 
     func testGlobalShortcutActionTogglesCapturing() {
-        var toggleCount = 0
-        manager.onToggleCapturingShortcut = {
-            toggleCount += 1
-        }
+        self.globalShortcutMonitor.performLastAction()
 
-        globalShortcutMonitor.performLastAction()
-
-        XCTAssertEqual(toggleCount, 1)
+        XCTAssertEqual(self.toggleCount, 1)
     }
 
     func testUnregistersGlobalShortcutOnDeinit() {
-        manager = nil
+        self.manager = nil
 
-        XCTAssertEqual(globalShortcutMonitor.removedActions.count, 1)
+        XCTAssertEqual(self.globalShortcutMonitor.removedActions.count, 1)
+    }
+
+    func testDisplaysShortcutInMenuItemsAtStartup() {
+        XCTAssertEqual(self.menuItemPresenter.displayedShortcuts, [ShortcutArchiver.defaultShortcut()])
+    }
+
+    func testRejectsInvalidShortcutWithoutPersistingOrRegistering() {
+        let shortcut = Shortcut(
+            code: .ansiA,
+            modifierFlags: [.command, .option],
+            characters: nil,
+            charactersIgnoringModifiers: nil
+        )
+        self.shortcutValidator.validationMessages[shortcut] = "Already used"
+
+        self.manager.toggleCapturingShortcut = shortcut
+
+        XCTAssertEqual(self.manager.shortcutValidationMessage, "Already used")
+        XCTAssertEqual(self.manager.toggleCapturingShortcut, ShortcutArchiver.defaultShortcut())
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.count, 1)
+        XCTAssertEqual(self.globalShortcutMonitor.removedActions.count, 0)
+    }
+
+    func testReportsInvalidStoredShortcutWithoutRegisteringIt() throws {
+        let shortcut = Shortcut(
+            code: .ansiB,
+            modifierFlags: [.control, .shift],
+            characters: nil,
+            charactersIgnoringModifiers: nil
+        )
+        self.store.set(try ShortcutArchiver.data(for: shortcut), forKey: ShortcutSettings.capturingHotKeyKey)
+        self.shortcutValidator.validationMessages[shortcut] = "Unavailable"
+
+        self.manager = self.makeManager()
+
+        XCTAssertEqual(self.manager.shortcutValidationMessage, "Unavailable")
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.count, 1)
+        XCTAssertEqual(self.globalShortcutMonitor.addedActions.first?.shortcut, ShortcutArchiver.defaultShortcut())
+    }
+
+    func testRecorderValidationRejectsInvalidShortcut() {
+        let shortcut = Shortcut(
+            code: .ansiA,
+            modifierFlags: [.command, .option],
+            characters: nil,
+            charactersIgnoringModifiers: nil
+        )
+        self.shortcutValidator.validationMessages[shortcut] = "Conflict"
+
+        let canRecord = self.manager.recorderControl(RecorderControl(frame: .zero), canRecord: shortcut)
+
+        XCTAssertFalse(canRecord)
+        XCTAssertEqual(self.manager.shortcutValidationMessage, "Conflict")
+    }
+
+    private func makeManager() -> ShortcutManager {
+        ShortcutManager(
+            settings: self.settings,
+            globalShortcutMonitor: self.globalShortcutMonitor,
+            shortcutValidator: self.shortcutValidator,
+            menuItemPresenter: self.menuItemPresenter,
+            onToggleCapturingShortcut: { [weak self] in
+                self?.toggleCount += 1
+            }
+        )
     }
 }
 
@@ -142,5 +220,21 @@ private final class FakeGlobalShortcutMonitor: GlobalShortcutMonitoring {
 
     func performLastAction() {
         self.addedActions.last?.perform(onTarget: nil)
+    }
+}
+
+private final class FakeShortcutValidator: ShortcutValidating {
+    var validationMessages: [Shortcut: String] = [:]
+
+    func validationMessage(for shortcut: Shortcut) -> String? {
+        self.validationMessages[shortcut]
+    }
+}
+
+private final class FakeShortcutMenuItemPresenter: ShortcutMenuItemPresenting {
+    private(set) var displayedShortcuts: [Shortcut?] = []
+
+    func displayShortcut(_ shortcut: Shortcut?) {
+        self.displayedShortcuts.append(shortcut)
     }
 }


### PR DESCRIPTION
## Summary

Refactors shortcut management by splitting global monitoring, validation, and menu item presentation behind focused abstractions. Adds validation state propagation to settings so invalid shortcuts can be surfaced to the user, with tests covering shortcut registration, persistence, validation failures, and  menu updates.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`


## UI Changes

<img width="905" height="648" alt="Screenshot 2026-07-21 at 15 39 03" src="https://github.com/user-attachments/assets/c8983819-b41b-4db3-aa6a-67c507cae491" />

## Documentation

- [x] No docs needed

## Release Notes

Improved shortcut handling reliability by refactoring global shortcut registration and validation, with clearer feedback when an assigned shortcut cannot be used.
