### PR TITLE
fix(keyboard): use Apple-style arrow key glyphs

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
@@ -32,10 +32,11 @@ enum UnicodeToken {
     static let pageUp: Unicode.Scalar = "\u{21DE}"
     static let pageDown: Unicode.Scalar = "\u{21DF}"
 
-    static let leftArrow: Unicode.Scalar = "\u{2190}"
-    static let rightArrow: Unicode.Scalar = "\u{2192}"
-    static let upArrow: Unicode.Scalar = "\u{2191}"
-    static let downArrow: Unicode.Scalar = "\u{2193}"
+    static let leftArrow: Unicode.Scalar = "\u{25C0}"
+    static let rightArrow: Unicode.Scalar = "\u{25B6}"
+    static let upArrow: Unicode.Scalar = "\u{25B2}"
+    static let downArrow: Unicode.Scalar = "\u{25BC}"
+    
     static let upLeftArrow: Unicode.Scalar = "\u{2196}"
     static let upRightArrow: Unicode.Scalar = "\u{2197}"
     static let downLeftArrow: Unicode.Scalar = "\u{2199}"
@@ -66,5 +67,6 @@ enum UnicodeToken {
     static let fastForward: Unicode.Scalar = "\u{23E9}"
     static let rewind: Unicode.Scalar = "\u{23EA}"
     static let eject: Unicode.Scalar = "\u{23CF}"
+    
     static let musicNote: Unicode.Scalar = "\u{266A}"
 }

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -183,13 +183,32 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         XCTAssertEqual(transform(keystroke), "⇤")
     }
 
+    func test_arrowKeysUseFilledTriangleSymbols() {
+        let cases: [(KeyboardKeyCode, String)] = [
+            (.leftArrow, "◀"),
+            (.upArrow, "▲"),
+            (.downArrow, "▼"),
+            (.rightArrow, "▶")
+        ]
+
+        for (keyCode, expected) in cases {
+            keystroke = makeKeystroke(
+                keyCode: keyCode.rawValue,
+                modifiers: NSEvent.ModifierFlags(rawValue: 256),
+                characters: expected,
+                charactersIgnoringModifiers: expected
+            )
+            XCTAssertEqual(transform(keystroke), expected)
+        }
+    }
+
     // MARK: - US English - Special Cases with Modifiers
 
     func test_optionShiftUp() {
         let ch = String(format: "%lu", UInt64(0x00006000002f5c00))
         keystroke = makeKeystroke(keyCode: 126, modifiers: NSEvent.ModifierFlags(rawValue: 11141410), characters: ch, charactersIgnoringModifiers: ch)
 
-        XCTAssertEqual(transform(keystroke), "⌥⇧↑")
+        XCTAssertEqual(transform(keystroke), "⌥⇧▲")
     }
 
     func test_optionUSpecialCase() {


### PR DESCRIPTION
## Summary

Use filled triangle glyphs for arrow key display to better match Apple keyboard legends

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

## Documentation

- [x] No docs needed

## Release Notes

Changed arrow key display from stemmed arrows to filled triangle glyphs to better match Apple keyboard legends.