### PR TITLE
 feat(keyboard): distinguish Return and keypad Enter rendering

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Domain/Keyboard/KeyboardGlyphCatalog.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Keyboard/KeyboardGlyphCatalog.swift
@@ -42,8 +42,10 @@ enum KeyboardGlyphCatalog {
             return UnicodeToken.escape.string
         case .delete, .forwardDelete:
             return UnicodeToken.delete.string
-        case .returnKey, .keypadEnter:
+        case .returnKey:
             return UnicodeToken.returnKey.string
+        case .keypadEnter:
+            return UnicodeToken.keypadEnter.string
         case .tab:
             return tab
         case .space:
@@ -61,8 +63,10 @@ enum KeyboardGlyphCatalog {
             return UnicodeToken.escape.string
         case "DELETE", "BACKSPACE":
             return UnicodeToken.delete.string
-        case "RETURN", "ENTER":
+        case "RETURN":
             return UnicodeToken.returnKey.string
+        case "ENTER":
+            return UnicodeToken.keypadEnter.string
         case "TAB":
             return tab
         case "SPACE":

--- a/Apps/Keyty/Sources/Keyty/Domain/Keyboard/KeyboardKeyCode.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Keyboard/KeyboardKeyCode.swift
@@ -186,7 +186,8 @@ extension KeyboardKeyCode {
         case .tab:                     return "tab"
         case .escape:                  return "esc"
         case .delete, .forwardDelete:  return "delete"
-        case .returnKey, .keypadEnter: return "return"
+        case .returnKey:               return "return"
+        case .keypadEnter:             return "enter"
         case .capsLock:                return "caps lock"
         default:                       return nil
         }
@@ -223,8 +224,10 @@ extension KeyboardKeyCode {
             return UnicodeToken.pageUp.string
         case .pageDown:
             return UnicodeToken.pageDown.string
-        case .returnKey, .keypadEnter:
+        case .returnKey:
             return UnicodeToken.returnKey.string
+        case .keypadEnter:
+            return UnicodeToken.keypadEnter.string
         case .brightnessDown:
             return UnicodeToken.brightnessDown.string
         case .brightnessUp:

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeycapItemFactory.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeycapItemFactory.swift
@@ -248,10 +248,17 @@ enum KeycapItemFactory {
                 state: KeycapState(isPressed: isPressed),
                 appearance: appearance
             )
-        case .returnKey, .keypadEnter:
+        case .returnKey:
             return KeycapItem(
                 identity: identity,
                 legend: .return,
+                state: KeycapState(isPressed: isPressed),
+                appearance: appearance
+            )
+        case .keypadEnter:
+            return KeycapItem(
+                identity: identity,
+                legend: .enter,
                 state: KeycapState(isPressed: isPressed),
                 appearance: appearance
             )

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Models/KeycapLegend.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Models/KeycapLegend.swift
@@ -54,6 +54,7 @@ extension KeycapLegend {
     static let escape = KeycapLegend(symbol: KeyboardGlyphCatalog.symbol(for: .escape), label: KeyboardKeyCode.escape.label)
     static let delete = KeycapLegend(symbol: KeyboardGlyphCatalog.symbol(for: .delete), label: KeyboardKeyCode.delete.label)
     static let `return` = KeycapLegend(symbol: KeyboardGlyphCatalog.symbol(for: .returnKey), label: KeyboardKeyCode.returnKey.label)
+    static let enter = KeycapLegend(symbol: KeyboardGlyphCatalog.symbol(for: .keypadEnter), label: KeyboardKeyCode.keypadEnter.label)
     static let space = KeycapLegend(symbol: KeyboardGlyphCatalog.symbol(for: .space))
     static let capsLock = KeycapLegend(label: KeyboardKeyCode.capsLock.label)
 }

--- a/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
@@ -24,7 +24,10 @@ enum UnicodeToken {
     static let delete: Unicode.Scalar = "\u{232B}"
     static let keypadClear: Unicode.Scalar = "\u{2327}"
     static let forwardDelete: Unicode.Scalar = "\u{2326}"
+    
     static let returnKey: Unicode.Scalar = "\u{21A9}"
+    static let keypadEnter: Unicode.Scalar = "\u{2305}"
+    
     static let questionMark: Unicode.Scalar = "\u{003F}"
     static let enclosingCircle: Unicode.Scalar = "\u{20DD}"
     static let home: Unicode.Scalar = "\u{2196}"

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
@@ -69,6 +69,32 @@ final class KeycapItemFactoryTests: XCTestCase {
         XCTAssertEqual(items.map(\.identity), [.modifier(.leftCommand)])
     }
 
+    func testReturnAndKeypadEnterRenderDifferentLegends() {
+        let palette = Self.makePalette()
+
+        let returnItems = KeycapItemFactory.keycapItems(
+            keyCode: KeyboardKeyCode.returnKey.rawValue,
+            displayString: KeyboardKeyCode.returnKey.displayText ?? "",
+            modifierFlags: [],
+            isPressed: true,
+            palette: palette
+        )
+        let enterItems = KeycapItemFactory.keycapItems(
+            keyCode: KeyboardKeyCode.keypadEnter.rawValue,
+            displayString: KeyboardKeyCode.keypadEnter.displayText ?? "",
+            modifierFlags: [],
+            isPressed: true,
+            palette: palette
+        )
+
+        XCTAssertEqual(returnItems.map(\.identity), [.keyCode(KeyboardKeyCode.returnKey.rawValue)])
+        XCTAssertEqual(returnItems.first?.symbol, UnicodeToken.returnKey.string)
+        XCTAssertEqual(returnItems.first?.label, "return")
+        XCTAssertEqual(enterItems.map(\.identity), [.keyCode(KeyboardKeyCode.keypadEnter.rawValue)])
+        XCTAssertEqual(enterItems.first?.symbol, UnicodeToken.keypadEnter.string)
+        XCTAssertEqual(enterItems.first?.label, "enter")
+    }
+
     func testMouseItemUsesPressedStateFromMouseEventType() {
         let palette = Self.makePalette()
 

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -177,6 +177,24 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         XCTAssertEqual(transform(keystroke), "⇥")
     }
 
+    func test_returnAndKeypadEnterUseDifferentSymbols() {
+        keystroke = makeKeystroke(
+            keyCode: KeyboardKeyCode.returnKey.rawValue,
+            modifiers: NSEvent.ModifierFlags(rawValue: 256),
+            characters: "\r",
+            charactersIgnoringModifiers: "\r"
+        )
+        XCTAssertEqual(transform(keystroke), UnicodeToken.returnKey.string)
+
+        keystroke = makeKeystroke(
+            keyCode: KeyboardKeyCode.keypadEnter.rawValue,
+            modifiers: NSEvent.ModifierFlags(rawValue: 256),
+            characters: "\r",
+            charactersIgnoringModifiers: "\r"
+        )
+        XCTAssertEqual(transform(keystroke), UnicodeToken.keypadEnter.string)
+    }
+
     func test_shiftTab() {
         let ch = String(UnicodeScalar(0x19)!)
         keystroke = makeKeystroke(keyCode: 48, modifiers: NSEvent.ModifierFlags(rawValue: 131330), characters: ch, charactersIgnoringModifiers: ch)


### PR DESCRIPTION
## Summary

Render Return and keypad Enter with distinct labels/glyphs

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

N/A

## Documentation

- [x] No docs needed

## Release Notes

Distinguishes Return and keypad Enter in the keyboard visualizer.
