### PR TITLE
fix(keyboard): anchor arrow symbols

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
@@ -48,13 +48,7 @@ struct DisplaysSettingsPane: View {
                     title: L10n.Displays.anchorLabel,
                     subtitle: L10n.Displays.anchorSubtitle
                 ) {
-                    Picker("", selection: $model.selectedAnchor) {
-                        ForEach(KeyboardVisualizerAnchor.allCases, id: \.self) { anchor in
-                            Text("\(anchor.symbol) \(anchor.label)").tag(anchor)
-                        }
-                    }
-                    .labelsHidden()
-                    .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
+                    KeyboardVisualizerAnchorPicker(selection: $model.selectedAnchor)
                 }
 
                 Divider()

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
@@ -145,13 +145,7 @@ struct KeyboardSettingsPane: View {
                 subtitle: L10n.KeyboardVisualizer.layoutSectionSubtitle
             ) {
                 SettingsControlRow(title: L10n.KeyboardVisualizer.anchorLabel, subtitle: L10n.KeyboardVisualizer.anchorSubtitle) {
-                    Picker("", selection: self.$model.anchor) {
-                        ForEach(KeyboardVisualizerAnchor.allCases, id: \.self) { anchor in
-                            Text(anchor.label).tag(anchor)
-                        }
-                    }
-                    .labelsHidden()
-                    .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
+                    KeyboardVisualizerAnchorPicker(selection: self.$model.anchor)
                 }
 
                 Divider()

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/KeyboardVisualizerAnchorPicker.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/KeyboardVisualizerAnchorPicker.swift
@@ -1,0 +1,23 @@
+//
+//  KeyboardVisualizerAnchorPicker.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import SwiftUI
+
+struct KeyboardVisualizerAnchorPicker: View {
+    @Binding var selection: KeyboardVisualizerAnchor
+
+    var body: some View {
+        Picker("", selection: self.$selection) {
+            ForEach(KeyboardVisualizerAnchor.allCases, id: \.self) { anchor in
+                Text("\(anchor.symbol) \(anchor.label)").tag(anchor)
+            }
+        }
+        .labelsHidden()
+        .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
+    }
+}

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Models/KeyboardVisualizerAnchor.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Models/KeyboardVisualizerAnchor.swift
@@ -19,12 +19,12 @@ struct KeyboardVisualizerAnchor: Hashable {
     var symbol: String {
         switch (self.vertical, self.horizontal) {
         case (.top, .leading):      UnicodeToken.upLeftArrow.string
-        case (.top, .center):       UnicodeToken.upArrow.string
+        case (.top, .center):       UnicodeToken.upwardsArrow.string
         case (.top, .trailing):     UnicodeToken.upRightArrow.string
-        case (.middle, .leading):   UnicodeToken.leftArrow.string
-        case (.middle, .trailing):  UnicodeToken.rightArrow.string
+        case (.middle, .leading):   UnicodeToken.leftwardsArrow.string
+        case (.middle, .trailing):  UnicodeToken.rightwardsArrow.string
         case (.bottom, .leading):   UnicodeToken.downLeftArrow.string
-        case (.bottom, .center):    UnicodeToken.downArrow.string
+        case (.bottom, .center):    UnicodeToken.downwardsArrow.string
         case (.bottom, .trailing):  UnicodeToken.downRightArrow.string
         case (.middle, .center):    UnicodeToken.bulletOperator.string
         }

--- a/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
@@ -39,6 +39,11 @@ enum UnicodeToken {
     static let rightArrow: Unicode.Scalar = "\u{25B6}"
     static let upArrow: Unicode.Scalar = "\u{25B2}"
     static let downArrow: Unicode.Scalar = "\u{25BC}"
+
+    static let leftwardsArrow: Unicode.Scalar = "\u{2190}"
+    static let rightwardsArrow: Unicode.Scalar = "\u{2192}"
+    static let upwardsArrow: Unicode.Scalar = "\u{2191}"
+    static let downwardsArrow: Unicode.Scalar = "\u{2193}"
     
     static let upLeftArrow: Unicode.Scalar = "\u{2196}"
     static let upRightArrow: Unicode.Scalar = "\u{2197}"

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Models/KeyboardVisualizerAnchorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Models/KeyboardVisualizerAnchorTests.swift
@@ -1,0 +1,19 @@
+//
+//  KeyboardVisualizerAnchorTests.swift
+//  KeytyTests
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import XCTest
+@testable import Keyty
+
+final class KeyboardVisualizerAnchorTests: XCTestCase {
+    func testSymbolUsesDirectionalArrowsForCardinalAnchors() {
+        XCTAssertEqual(KeyboardVisualizerAnchor.topCenter.symbol, "↑")
+        XCTAssertEqual(KeyboardVisualizerAnchor.middleLeft.symbol, "←")
+        XCTAssertEqual(KeyboardVisualizerAnchor.middleRight.symbol, "→")
+        XCTAssertEqual(KeyboardVisualizerAnchor.bottomCenter.symbol, "↓")
+    }
+}


### PR DESCRIPTION
## Summary

Shows directional anchor symbols consistently in Keyboard and Displays settings by sharing a single anchor picker implementation.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

Before
<img width="905" height="648" alt="Screenshot 2026-07-22 at 18 46 21" src="https://github.com/user-attachments/assets/4b078ffd-9b6d-4d56-b9bb-2ac425aaf548" />

After
<img width="905" height="648" alt="Screenshot 2026-07-22 at 18 56 02" src="https://github.com/user-attachments/assets/b3dc8f06-1e96-43ca-9c06-1d4843dd65ca" />


## Documentation

- [x] No docs needed

## Release Notes

Keyboard visualizer anchor selectors now show directional symbols consistently across settings panes.
