### PR TITLE
fix: show non-localized shortcut in status bar menu

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutMenuItemPresenter.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutMenuItemPresenter.swift
@@ -43,7 +43,7 @@ private extension ShortcutMenuItemPresenter {
 extension ShortcutMenuItemPresenter: ShortcutMenuItemPresenting {
     func displayShortcut(_ shortcut: Shortcut?) {
         if let shortcut {
-            let keyEquivalent = SymbolicKeyCodeTransformer.shared.transformedValue(NSNumber(value: shortcut.keyCode.rawValue)) ?? ""
+            let keyEquivalent = KeyEquivalentTransformer.shared.transformedValue(shortcut) ?? ""
             self.setKeyEquivalent(keyEquivalent)
             self.setKeyEquivalentModifierMask(shortcut.modifierFlags)
         } else {


### PR DESCRIPTION
## Summary

Remove localization of key of enable/disable shortcut in status menu item

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

| Before  | After |
| - | - |
| <img width="214" height="128" alt="Screenshot 2026-07-22 at 21 33 13" src="https://github.com/user-attachments/assets/20257889-3ba6-48f7-8f70-c6d4b36240d0" /> | <img width="213" height="128" alt="Screenshot 2026-07-22 at 21 33 31" src="https://github.com/user-attachments/assets/d6f46990-6f48-4339-8674-7a701761e5f5" /> |


## Documentation

- [x] No docs needed

## Release Notes

Remove localization of key of enable/disable shortcut in status menu item
