### PR TITLE
feat(settings): add info pane with app links

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Info/InfoSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Info/InfoSettingsPane.swift
@@ -1,0 +1,51 @@
+//
+//  InfoSettingsPane.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import SwiftUI
+
+struct InfoSettingsPane: View {
+    var body: some View {
+        SettingsStack {
+            SettingsSectionView {
+                SettingsLinkRow(
+                    title: L10n.Info.githubLabel,
+                    url: AppConstants.githubURL
+                )
+
+                Divider()
+
+                SettingsLinkRow(
+                    title: L10n.Info.websiteLabel,
+                    url: AppConstants.websiteURL
+                )
+
+                Divider()
+
+                SettingsLinkRow(
+                    title: L10n.Info.emailLabel,
+                    url: AppConstants.feedbackURL,
+                    displayText: AppConstants.feedbackEmail
+                )
+            }
+
+            HStack {
+                Spacer(minLength: Spacing.none)
+
+                Button(L10n.MainMenu.about(AppConstants.appName), action: self.showAbout)
+                    .buttonStyle(.bordered)
+                    .controlSize(.large)
+
+                Spacer(minLength: Spacing.none)
+            }
+        }
+    }
+
+    private func showAbout() {
+        NSApp.sendAction(#selector(AppController.orderFrontKeytyAboutPanel(_:)), to: nil, from: nil)
+    }
+}

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsFormRows.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsFormRows.swift
@@ -51,9 +51,42 @@ struct SettingsControlRow<Content: View>: View {
 
             self.content
                 .frame(minWidth: Size.Control.settingsPickerWidth, alignment: .trailing)
+                .layoutPriority(1)
         }
         .padding(.vertical, Spacing.none)
         .frame(maxWidth: .infinity, alignment: .center)
+    }
+}
+
+struct SettingsLinkRow: View {
+    let title: String
+    let url: URL
+    let displayText: String
+
+    init(title: String, url: URL, displayText: String? = nil) {
+        self.title = title
+        self.url = url
+        self.displayText = displayText ?? url.absoluteString
+    }
+
+    var body: some View {
+        SettingsControlRow(title: self.title) {
+            Link(destination: self.url) {
+                HStack(spacing: Spacing.xxs) {
+                    Text(self.displayText)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .layoutPriority(1)
+
+                    Image(systemName: "arrow.up.right.square")
+                        .imageScale(.small)
+                }
+                .font(Typography.Settings.rowTitle)
+                .foregroundColor(Color.Theme.Accent.controlAccent)
+            }
+            .help(self.url.absoluteString)
+            .frame(minWidth: Size.Control.settingsPickerWidth, alignment: .trailing)
+        }
     }
 }
 

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsPaneIdentifier.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsPaneIdentifier.swift
@@ -15,6 +15,7 @@ enum SettingsPaneIdentifier: String, CaseIterable {
     case displays
     case permissions
     case update
+    case info
 }
 
 extension SettingsPaneIdentifier {
@@ -36,6 +37,8 @@ extension SettingsPaneIdentifier {
             return L10n.Settings.Pane.permissions
         case .update:
             return L10n.Settings.Pane.update
+        case .info:
+            return L10n.Settings.Pane.info
         }
     }
 
@@ -53,6 +56,8 @@ extension SettingsPaneIdentifier {
             return "hand.raised.fill"
         case .update:
             return "arrow.trianglehead.clockwise"
+        case .info:
+            return "info.circle.fill"
         }
     }
 
@@ -70,6 +75,8 @@ extension SettingsPaneIdentifier {
             return Color.Theme.Palette.red
         case .update:
             return Color.Theme.Palette.teal
+        case .info:
+            return Color.Theme.Palette.green
         }
     }
 

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsPaneRegistry.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsPaneRegistry.swift
@@ -92,6 +92,14 @@ struct SettingsPaneRegistry {
                     AnyView(UpdateSettingsPane(updater: updater))
                 }
             ),
+            SettingsPaneEntry(
+                id: .info,
+                title: SettingsPaneIdentifier.info.label,
+                systemImageName: SettingsPaneIdentifier.info.sfSymbolName,
+                makeView: {
+                    AnyView(InfoSettingsPane())
+                }
+            ),
         ]
     }
 

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "settings.pane.displays" = "Displays";
 "settings.pane.permissions" = "Permissions";
 "settings.pane.update" = "Update";
+"settings.pane.info" = "Info";
 
 /* Anchor labels */
 "anchor.left" = "Left";
@@ -73,6 +74,11 @@
 "general.stop_capturing" = "Disable";
 "general.show_settings_at_launch" = "Show settings at launch";
 "general.show_settings_at_launch_subtitle" = "Reopen the settings window automatically when Keyty starts.";
+
+/* Info settings pane */
+"info.github_label" = "GitHub";
+"info.website_label" = "Website";
+"info.email_label" = "Email";
 
 /* Keyboard visualizer settings pane */
 "keyboard_visualizer.live_overlay_section_title" = "Live Overlay";


### PR DESCRIPTION
## Summary

Add info pane with app links

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

<img width="905" height="648" alt="Screenshot 2026-07-23 at 11 14 00" src="https://github.com/user-attachments/assets/c67371f1-2376-4b83-94fc-983afd64f92d" />

## Documentation

- [x] No docs needed

## Release Notes

Add info pane with app links
