### PR TITLE
fix(keycaps): remove unpressed Apple keycap highlight

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Renderers/AppleKeycapRenderer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Renderers/AppleKeycapRenderer.swift
@@ -44,17 +44,6 @@ struct AppleKeycapRenderer: KeycapRendering {
         path.lineWidth = StrokeWidth.standard
         path.stroke()
 
-        if !item.isPressed {
-            let highlightRect = NSRect(
-                x: keycapRect.minX + 4,
-                y: keycapRect.maxY - 2,
-                width: keycapRect.width - 8,
-                height: 1
-            )
-            NSColor(white: 1, alpha: 0.08).setFill()
-            NSBezierPath(rect: highlightRect).fill()
-        }
-
         legendRenderer.draw(item: item, in: keycapRect, textColor: appearance.textColor)
     }
 }


### PR DESCRIPTION
## Summary

Removes the unwanted highlight line from unpressed Apple-style keycaps.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

Before
<img width="588" height="204" alt="Screenshot 2026-07-24 at 12 13 07" src="https://github.com/user-attachments/assets/0470681e-c937-486b-9511-05898ca0dedd" />

After
<img width="588" height="204" alt="Screenshot 2026-07-24 at 12 27 14" src="https://github.com/user-attachments/assets/97722d6d-802e-4b70-8216-afc70ef3f26f" />

## Documentation

- [ ] Updated relevant docs
- [ ] No docs needed

## Release Notes

Apple-style keycaps now render cleanly without an unintended line across their surface.
