### PR TITLE
refactor(l10n): migrate to generated  string accessors

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowViewModel.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowViewModel.swift
@@ -21,15 +21,14 @@ final class AboutWindowViewModel: ObservableObject {
 
     init(bundle: Bundle = .main) {
         self.appName = AppConstants.appName
-        self.versionString = String(
-            format: NSLocalizedString("about.version", comment: "About version"),
+        self.versionString = L10n.About.version(
             bundle.appVersionString,
             bundle.appBuildString
         )
         self.license = [
             Section(
-                title: NSLocalizedString("about.license.keyty_title", comment: "Keyty license heading"),
-                subtitle: NSLocalizedString("about.license.keyty_subtitle", comment: "Keyty license subtitle"),
+                title: L10n.About.License.keytyTitle,
+                subtitle: L10n.About.License.keytySubtitle,
                 links: [
                     LinkItem(title: "GitHub", url: AppConstants.githubURL),
                     LinkItem(title: "Website", url: AppConstants.websiteURL)
@@ -50,20 +49,20 @@ final class AboutWindowViewModel: ObservableObject {
         ]
         self.contributors = [
             Section(
-                title: NSLocalizedString("about.contributors.title", comment: "Contributors heading"),
-                subtitle: NSLocalizedString("about.contributors.subtitle", comment: "Contributors subtitle"),
+                title: L10n.About.Contributors.title,
+                subtitle: L10n.About.Contributors.subtitle,
                 listItems: [
                     ListItem(
-                        title: NSLocalizedString("about.contributors.serhii_bykov", comment: "Serhii Bykov contributor name")
+                        title: L10n.About.Contributors.serhiiBykov
                     ),
                     ListItem(
-                        title: NSLocalizedString("about.contributors.yullia_babichuk", comment: "Yullia Babichuk contributor name")
+                        title: L10n.About.Contributors.yulliaBabichuk
                     ),
                     ListItem(
-                        title: NSLocalizedString("about.contributors.oleksii_petruk", comment: "Oleksii Petruk contributor name")
+                        title: L10n.About.Contributors.oleksiiPetruk
                     ),
                     ListItem(
-                        title: NSLocalizedString("about.contributors.serhii_butenko", comment: "Serhii Butenko contributor name")
+                        title: L10n.About.Contributors.serhiiButenko
                     )
                 ]
             )
@@ -71,7 +70,7 @@ final class AboutWindowViewModel: ObservableObject {
         self.credits = [
             Section(
                 title: "Sparkle",
-                subtitle: NSLocalizedString("about.credits.sparkle_subtitle", comment: "Sparkle subtitle"),
+                subtitle: L10n.About.Credits.sparkleSubtitle,
                 body: LicenseLoader.text(
                     named: "Sparkle",
                     trimmingLeadingLines: [
@@ -82,7 +81,7 @@ final class AboutWindowViewModel: ObservableObject {
             ),
             Section(
                 title: "AppMover",
-                subtitle: NSLocalizedString("about.credits.app_mover_subtitle", comment: "AppMover subtitle"),
+                subtitle: L10n.About.Credits.appMoverSubtitle,
                 body: LicenseLoader.text(
                     named: "AppMover",
                     trimmingLeadingLines: [
@@ -92,7 +91,7 @@ final class AboutWindowViewModel: ObservableObject {
             ),
             Section(
                 title: "ShortcutRecorder",
-                subtitle: NSLocalizedString("about.credits.shortcut_recorder_subtitle", comment: "ShortcutRecorder subtitle"),
+                subtitle: L10n.About.Credits.shortcutRecorderSubtitle,
                 body: LicenseLoader.text(
                     named: "ShortcutRecorder",
                     trimmingLeadingLines: [
@@ -147,11 +146,11 @@ extension AboutWindowViewModel {
         var title: String {
             switch self {
             case .license:
-                NSLocalizedString("about.tab.license", comment: "License tab")
+                L10n.About.Tab.license
             case .contributors:
-                NSLocalizedString("about.tab.contributors", comment: "Contributors tab")
+                L10n.About.Tab.contributors
             case .credits:
-                NSLocalizedString("about.tab.credits", comment: "Credits tab")
+                L10n.About.Tab.credits
             }
         }
     }
@@ -176,7 +175,7 @@ extension AboutWindowViewModel {
             }
         }
 
-        return NSLocalizedString("about.credits.license_missing", comment: "Missing bundled license fallback")
+        return L10n.About.Credits.licenseMissing
     }
 
     private static func sanitized(_ text: String, trimmingLeadingLines linesToTrim: [String]) -> String {

--- a/Apps/Keyty/Sources/Keyty/Platform/Capture/EventTap/EventTap+Error.swift
+++ b/Apps/Keyty/Sources/Keyty/Platform/Capture/EventTap/EventTap+Error.swift
@@ -16,15 +16,9 @@ extension EventTap {
         var errorDescription: String? {
             switch self {
             case .keyTapCreationFailed:
-                return NSLocalizedString(
-                    "Could not create key event tap. Accessibility permission is required.",
-                    comment: "Shown when the key event tap cannot be installed"
-                )
+                return L10n.EventTap.keyTapCreationFailed
             case .mouseAndFlagsTapCreationFailed:
-                return NSLocalizedString(
-                    "Could not create mouse and modifiers event tap.",
-                    comment: "Shown when the mouse/flags event tap cannot be installed"
-                )
+                return L10n.EventTap.mouseAndFlagsTapCreationFailed
             }
         }
     }

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -59,6 +59,10 @@
 "general.show_settings_at_launch" = "Show settings at launch";
 "general.show_settings_at_launch_subtitle" = "Reopen the settings window automatically when Keyty starts.";
 
+/* Event capture */
+"event_tap.key_tap_creation_failed" = "Could not create key event tap. Accessibility permission is required.";
+"event_tap.mouse_and_flags_tap_creation_failed" = "Could not create mouse and modifiers event tap.";
+
 /* Info settings pane */
 "info.github_label" = "GitHub";
 "info.website_label" = "Website";

--- a/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutValidating.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Shortcuts/ShortcutValidating.swift
@@ -21,10 +21,9 @@ extension ShortcutValidator: ShortcutValidating {
             try self.validate(shortcut: shortcut)
             return nil
         } catch {
-            return error.localizedDescription.isEmpty ? NSLocalizedString(
-                "general.shortcut_validation_fallback",
-                comment: "Fallback shortcut validation failure message"
-            ) : error.localizedDescription
+            return error.localizedDescription.isEmpty
+                ? L10n.General.shortcutValidationFallback
+                : error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
## Summary

Migrates remaining `NSLocalizedString` calls to type-safe generated L10n accessors and adds semantic localization keys for event-capture errors.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

N/A

## Documentation

- [x] No docs needed

## Release Notes

Improved localization consistency across the app.
