### PR TITLE
fix(settings): replace axis segmented control with dropdown

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
@@ -348,8 +348,7 @@ struct KeyboardSettingsPane: View {
                 .tag(KeyboardVisualizerStackAxis.horizontal)
         }
         .labelsHidden()
-        .pickerStyle(.segmented)
-        .frame(width: Spacing.grid(34))
+        .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
     }
 
 }


### PR DESCRIPTION
## Summary

Replaces the keyboard axis segmented control with a dropdown to prevent long localized labels from overflowing.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

Before
<img width="905" height="648" alt="Screenshot 2026-07-24 at 13 27 03" src="https://github.com/user-attachments/assets/e10ce188-412e-4bc0-8f20-d68f7d106199" />

After
<img width="905" height="648" alt="Screenshot 2026-07-24 at 13 30 48" src="https://github.com/user-attachments/assets/b833a275-7ba1-4a95-990e-74d0421b0a9f" />

## Documentation

- [x] No docs needed

## Release Notes

Improved the keyboard layout settings for languages with longer labels.
