### PR TITLE
fix(settings): constrain shortcut recorder width

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Support/Bridges/ShortcutRecorder/ShortcutRecorderView.swift
+++ b/Apps/Keyty/Sources/Keyty/Support/Bridges/ShortcutRecorder/ShortcutRecorderView.swift
@@ -14,6 +14,7 @@ struct ShortcutRecorderView: NSViewRepresentable {
 
     func makeNSView(context: Context) -> RecorderControl {
         let recorder = RecorderControl(frame: .zero)
+        recorder.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         shortcutManager.configureToggleShortcutRecorder(recorder)
         return recorder
     }


### PR DESCRIPTION
## Summary

Prevents localized ShortcutRecorder prompts from expanding the settings control by allowing it to compress to Keyty’s standard width.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug`

Run project commands from `Apps/Keyty`.

## UI Changes

Keeps the shortcut recorder consistently sized across languages with longer internal labels.

Before
<img width="905" height="648" alt="Screenshot 2026-07-24 at 15 04 23" src="https://github.com/user-attachments/assets/f63ec5b3-b5d9-4bc8-b6ad-527da943c906" />

After
<img width="905" height="648" alt="Screenshot 2026-07-24 at 15 22 34" src="https://github.com/user-attachments/assets/688995cf-f043-4c51-b434-c0c9d209d0a3" />


## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Fixed an oversized shortcut recorder in languages with longer labels.