### PR TITLE
docs(readme): link logo to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://github.com/esphynox/Keyty">
+  <a href="https://keyty.app">
     <img src="Assets/Application/AppIcon/AppIcon.png" alt="Keyty app logo" width="128">
     <br />
     <strong>Keyty</strong>


### PR DESCRIPTION
## Summary

- Update the README logo link to point to the Keyty website.

## Why

The logo should direct visitors to the product website instead of linking back to the GitHub repository they are already viewing.

## Impact

Clicking the Keyty logo in the README now opens https://keyty.app. No application behavior is affected.

## Validation

- `git diff --check`