### PR TITLE
chore(release): categorize generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  exclude:
+    labels:
+      - ignore for release
+  categories:
+    - title: New features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary

- Add GitHub generated release-note configuration.
- Group labeled pull requests into New features and Bug fixes.
- Collect all remaining entries under Other changes.
- Exclude entries labeled `ignore for release`.

## Why

Generated release notes need predictable categories so changelogs are easier to scan and non-user-facing entries can be omitted.

## Impact

Future GitHub-generated release notes will be organized by label. This does not change the Keyty app or its build configuration.

## Validation

- `git diff --check origin/main...origin/chore/configure-release-notes`