### PR TITLE
chore(release): prepare v1.0.0

### DIFF
--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -12,7 +12,7 @@ let appSettings: SettingsDictionary = [
     "ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS": "YES",
     "CLANG_ENABLE_OBJC_WEAK": "YES",
     "CODE_SIGN_ENTITLEMENTS": "Sources/Keyty/Resources/Keyty.entitlements",
-    "CURRENT_PROJECT_VERSION": "87",
+    "CURRENT_PROJECT_VERSION": "100",
     "DEAD_CODE_STRIPPING": "YES",
     "ENABLE_HARDENED_RUNTIME": "YES",
     "FRAMEWORK_SEARCH_PATHS": [
@@ -28,7 +28,7 @@ let appSettings: SettingsDictionary = [
         "$(inherited)",
         "@executable_path/../Frameworks",
     ],
-    "MARKETING_VERSION": "0.8.7",
+    "MARKETING_VERSION": "1.0.0",
     "PRODUCT_BUNDLE_IDENTIFIER": "app.keyty.Keyty",
     "PRODUCT_NAME": "Keyty",
     "PROVISIONING_PROFILE_SPECIFIER": "",


### PR DESCRIPTION
## Summary

- set the Keyty marketing version to `1.0.0`
- set the Sparkle/build number to `100`

## Impact

Prepares the canonical project settings for the `v1.0.0` production release. The release tag will trigger the signed, notarized GitHub Actions release workflow after this PR is merged.

## Validation

- `tuist generate --no-open`
- `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug`
- `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination platform=macOS` — 204 tests passed
- Release build settings resolve to `MARKETING_VERSION = 1.0.0` and `CURRENT_PROJECT_VERSION = 100`