### PR TITLE
chore: update GitHub organization URLs

### DIFF
--- a/Apps/Keyty/Sources/Keyty/App/Support/AppConstants.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Support/AppConstants.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 enum AppConstants {
-    private static let repositoryBaseURL = "https://github.com/esphynox/Keyty"
+    private static let repositoryBaseURL = "https://github.com/keytyapp/Keyty"
 
     static var appName: String {
         Bundle.main.displayName ?? Bundle.main.name ?? "Keyty"

--- a/Docs/BUILD.md
+++ b/Docs/BUILD.md
@@ -10,7 +10,7 @@
 ## Cloning
 
 ```bash
-git clone https://github.com/esphynox/Keyty.git
+git clone https://github.com/keytyapp/Keyty.git
 cd Keyty
 ```
 

--- a/Docs/DEVELOPING.md
+++ b/Docs/DEVELOPING.md
@@ -13,7 +13,7 @@ This guide covers the local contributor workflow for building, running, testing,
 Clone the repository and open the Xcode project:
 
 ```bash
-git clone https://github.com/esphynox/Keyty.git
+git clone https://github.com/keytyapp/Keyty.git
 cd Keyty
 brew install tuist
 cd Apps/Keyty

--- a/Docs/RELEASING.md
+++ b/Docs/RELEASING.md
@@ -56,7 +56,7 @@ Optionally configure these repository variables:
 
 | Variable | Description |
 |---|---|
-| `APPCAST_DOWNLOAD_PREFIX` | Sparkle enclosure URL prefix. By default, the release lane uses the current GitHub release asset URL, such as `https://github.com/esphynox/Keyty/releases/download/v0.8.0/` |
+| `APPCAST_DOWNLOAD_PREFIX` | Sparkle enclosure URL prefix. By default, the release lane uses the current GitHub release asset URL, such as `https://github.com/keytyapp/Keyty/releases/download/v0.8.0/` |
 | `STAGING_APPCAST_URL` | Feed URL compiled into staging builds, default `https://keyty.app/staging/appcast.xml` |
 | `STAGING_APPCAST_DOWNLOAD_PREFIX` | Staging Sparkle enclosure URL prefix. By default, the staging lane uses the current GitHub prerelease asset URL |
 | `KEYTY_RELEASE_TEAM_ID` | Developer ID team, default `NEVA4MAZBL` |
@@ -76,7 +76,7 @@ other fetch failures stop the lane before creating the GitHub release.
 
 - `Keyty.zip` is the Sparkle update archive and the input to appcast generation.
 - `Keyty.dmg` is the manual-download artifact attached to the GitHub release.
-- The stable artifact names support GitHub's latest-release download URLs, for example `https://github.com/esphynox/Keyty/releases/latest/download/Keyty.dmg`.
+- The stable artifact names support GitHub's latest-release download URLs, for example `https://github.com/keytyapp/Keyty/releases/latest/download/Keyty.dmg`.
 - Appcast generation reads the zip from an appcast-only directory so the DMG is
   not scanned as a duplicate update.
 - Production and staging appcasts are cumulative. Previous appcast items keep
@@ -156,7 +156,7 @@ the GitHub prerelease asset. The updated staging appcast will include both the
 `0.9.0` and `0.9.1` staging items until you reset it:
 
 ```text
-https://github.com/esphynox/Keyty/releases/download/v0.9.1-test/Keyty.zip
+https://github.com/keytyapp/Keyty/releases/download/v0.9.1-test/Keyty.zip
 ```
 
 After testing, delete the staging prereleases and tags:
@@ -205,8 +205,8 @@ git push --tags
 7. Download the `appcast-artifacts` workflow artifact and publish `appcast.xml` through the Vercel-hosted site.
 8. Verify the published appcast artifacts are available at the feed host:
    - `https://keyty.app/appcast.xml`
-   - `https://github.com/esphynox/Keyty/releases/download/v<NEW_VERSION>/Keyty.zip`
-   - `https://github.com/esphynox/Keyty/releases/latest/download/Keyty.dmg`
+   - `https://github.com/keytyapp/Keyty/releases/download/v<NEW_VERSION>/Keyty.zip`
+   - `https://github.com/keytyapp/Keyty/releases/latest/download/Keyty.dmg`
 9. Inspect the `appcast-artifacts` workflow artifact if you need to verify the exact files generated:
    - `appcast/Keyty.zip` for Sparkle
    - `Keyty.dmg` for GitHub Releases/manual downloads

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 </h1>
 
 <div>
-   <img src="https://img.shields.io/github/v/release/esphynox/Keyty?style=flat-square" alt="Releases">
-   <img src="https://img.shields.io/github/downloads/esphynox/Keyty/total?style=flat-square" alt="Downloads">
-   <img src="https://img.shields.io/github/stars/esphynox/Keyty?style=flat-square" alt="Stars">
-   <img src="https://img.shields.io/github/license/esphynox/Keyty?style=flat-square" alt="License">
+   <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="Releases">
+   <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="Downloads">
+   <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="Stars">
+   <img src="https://img.shields.io/github/license/keytyapp/Keyty?style=flat-square" alt="License">
    <img src="https://img.shields.io/badge/platform-macOS-lightgrey?style=flat-square" alt="Platform Support">
 </div>
 
@@ -54,7 +54,7 @@ Keyty can be tuned from Settings to match your workflow and presentation style:
 
 ### Github
 
-Download the latest release from [GitHub](https://github.com/esphynox/Keyty/releases)
+Download the latest release from [GitHub](https://github.com/keytyapp/Keyty/releases)
 
 ### Build from Source
 


### PR DESCRIPTION
## Summary

- update in-app GitHub and permissions-documentation links to `keytyapp/Keyty`
- update README badges and release links to the organization repository
- update contributor clone commands and release documentation examples

## Impact

Makes `keytyapp/Keyty` the canonical repository throughout the app and project documentation after the GitHub organization transfer. Existing `esphynox/Keyty` redirects remain functional, but new links no longer depend on them.

## Validation

- case-insensitive repository scan confirms no remaining `esphynox/Keyty` references
- `git diff --check`
- `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug` — signed Debug build succeeded
