### PR TITLE
docs: add Homebrew installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,15 @@ Keyty can be tuned from Settings to match your workflow and presentation style:
 
 ## Installation
 
-### Github
+### GitHub
 
 Download the latest release from [GitHub](https://github.com/keytyapp/Keyty/releases)
+
+### Homebrew
+
+```bash
+brew install --cask keytyapp/tap/keyty
+```
 
 ### Build from Source
 


### PR DESCRIPTION
## Summary

- add the Homebrew cask installation command beneath the direct GitHub release option
- correct the `Github` heading capitalization to `GitHub`

## Impact

Users can discover and copy the supported Homebrew installation command directly from the README.

## Validation

- `git diff --check`
- documentation-only change; no application build required
