### PR TITLE
refactor(events): rename media key press state

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Domain/Events/MediaKeyEvent.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Events/MediaKeyEvent.swift
@@ -45,7 +45,7 @@ public struct MediaKeyEvent {
     public let modifierFlags: NSEvent.ModifierFlags
     public let kind: Kind
     /// `true` for a press (`NX_KEYDOWN`, state `0xA`), `false` for the release.
-    public let isDown: Bool
+    public let isPressed: Bool
 
     /// `false` for aux-control events that are not media keys (caps lock, power,
     /// num lock, …) and so should not be displayed — caps lock in particular is
@@ -63,7 +63,7 @@ public struct MediaKeyEvent {
         let keyCode = (data1 & 0xFFFF0000) >> 16
         let keyState = (data1 & 0xFF00) >> 8
         self.kind = Kind(keyCode: keyCode)
-        self.isDown = keyState == 0x0A
+        self.isPressed = keyState == 0x0A
     }
 
     public var inputEvent: InputEvent {

--- a/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
+++ b/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
@@ -193,7 +193,7 @@ extension CaptureController: EventTapDelegate {
     }
 
     func eventTap(_ tap: EventTap, noteMediaKey mediaKey: MediaKeyEvent) {
-        guard self.isCapturing, mediaKey.isDown, mediaKey.isRecognized else { return }
+        guard self.isCapturing, mediaKey.isPressed, mediaKey.isRecognized else { return }
         self.eventProcessor.noteMediaKey(mediaKey)
     }
 


### PR DESCRIPTION
## Summary

Renamed `MediaKeyEvent.isDown` to `isPressed` to match the press-state terminology used elsewhere in the project.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination "platform=macOS"`
- [x] Other: `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A