### PR TITLE
fix(settings): label hidden settings controls

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
@@ -39,6 +39,7 @@ struct DisplaysSettingsPane: View {
                         }
                     }
                     .labelsHidden()
+                    .accessibilityLabel(L10n.Displays.displayLabel)
                     .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
                 }
 
@@ -48,7 +49,10 @@ struct DisplaysSettingsPane: View {
                     title: L10n.Displays.anchorLabel,
                     subtitle: L10n.Displays.anchorSubtitle
                 ) {
-                    KeyboardVisualizerAnchorPicker(selection: $model.selectedAnchor)
+                    KeyboardVisualizerAnchorPicker(
+                        selection: $model.selectedAnchor,
+                        accessibilityLabel: L10n.Displays.anchorLabel
+                    )
                 }
 
                 Divider()
@@ -60,7 +64,8 @@ struct DisplaysSettingsPane: View {
                     SettingsSliderControl(
                         value: $model.windowPadding,
                         range: model.paddingRange,
-                        step: model.paddingStep
+                        step: model.paddingStep,
+                        accessibilityLabel: L10n.Displays.marginLabel
                     )
                 }
             }

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/General/GeneralSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/General/GeneralSettingsPane.swift
@@ -27,6 +27,7 @@ struct GeneralSettingsPane: View {
                 ) {
                     Toggle("", isOn: $model.visibleAtLaunch)
                         .labelsHidden()
+                        .accessibilityLabel(L10n.General.showSettingsAtLaunch)
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
@@ -103,6 +103,7 @@ struct KeyboardSettingsPane: View {
                 ) {
                     Toggle("", isOn: self.$model.onlyShowModifiedKeystrokes)
                         .labelsHidden()
+                        .accessibilityLabel(L10n.KeyboardVisualizer.onlyShowModifiedKeystrokesLabel)
                         .toggleStyle(.switch)
                 }
 
@@ -114,6 +115,7 @@ struct KeyboardSettingsPane: View {
                 ) {
                     Toggle("", isOn: self.$model.showSpecialKeys)
                         .labelsHidden()
+                        .accessibilityLabel(L10n.KeyboardVisualizer.showSpecialKeysLabel)
                         .toggleStyle(.switch)
                 }
 
@@ -125,6 +127,7 @@ struct KeyboardSettingsPane: View {
                 ) {
                     Toggle("", isOn: self.$model.showMediaKeyButtons)
                         .labelsHidden()
+                        .accessibilityLabel(L10n.KeyboardVisualizer.showMediaKeyButtonsLabel)
                         .toggleStyle(.switch)
                 }
 
@@ -136,6 +139,7 @@ struct KeyboardSettingsPane: View {
                 ) {
                     Toggle("", isOn: self.$model.showMouseEvents)
                         .labelsHidden()
+                        .accessibilityLabel(L10n.KeyboardVisualizer.showMouseEventsLabel)
                         .toggleStyle(.switch)
                 }
             }
@@ -145,7 +149,10 @@ struct KeyboardSettingsPane: View {
                 subtitle: L10n.KeyboardVisualizer.layoutSectionSubtitle
             ) {
                 SettingsControlRow(title: L10n.KeyboardVisualizer.anchorLabel, subtitle: L10n.KeyboardVisualizer.anchorSubtitle) {
-                    KeyboardVisualizerAnchorPicker(selection: self.$model.anchor)
+                    KeyboardVisualizerAnchorPicker(
+                        selection: self.$model.anchor,
+                        accessibilityLabel: L10n.KeyboardVisualizer.anchorLabel
+                    )
                 }
 
                 Divider()
@@ -154,7 +161,8 @@ struct KeyboardSettingsPane: View {
                     SettingsSliderControl(
                         value: self.$model.scale,
                         range: self.model.scaleRange,
-                        step: self.model.scaleStep
+                        step: self.model.scaleStep,
+                        accessibilityLabel: L10n.KeyboardVisualizer.sizeLabel
                     )
                 }
             }
@@ -172,6 +180,7 @@ struct KeyboardSettingsPane: View {
 
                         Stepper("", value: self.$model.maxCount, in: self.model.maxCountRange)
                             .labelsHidden()
+                            .accessibilityLabel(L10n.KeyboardVisualizer.maxCountLabel)
                     }
                 }
 
@@ -194,7 +203,8 @@ struct KeyboardSettingsPane: View {
                         edgeLabels: SettingsSliderEdgeLabels(
                             leading: L10n.KeyboardVisualizer.LingerTime.short,
                             trailing: L10n.KeyboardVisualizer.LingerTime.long
-                        )
+                        ),
+                        accessibilityLabel: L10n.KeyboardVisualizer.lingerTimeLabel
                     )
                 }
 
@@ -208,7 +218,8 @@ struct KeyboardSettingsPane: View {
                         edgeLabels: SettingsSliderEdgeLabels(
                             leading: L10n.KeyboardVisualizer.FadeDuration.fast,
                             trailing: L10n.KeyboardVisualizer.FadeDuration.slow
-                        )
+                        ),
+                        accessibilityLabel: L10n.KeyboardVisualizer.fadeDurationLabel
                     )
                 }
             }
@@ -237,6 +248,7 @@ struct KeyboardSettingsPane: View {
                     .tag(KeyboardSettingsPaneViewModel.ThemeSelection.custom)
             }
             .labelsHidden()
+            .accessibilityLabel(L10n.KeyboardVisualizer.themeLabel)
             .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
         }
     }
@@ -282,6 +294,7 @@ struct KeyboardSettingsPane: View {
             )
         }
         .labelsHidden()
+        .accessibilityLabel(L10n.KeyboardVisualizer.legendColorLabel)
         .pickerStyle(.menu)
         .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
         .onAppear {
@@ -309,6 +322,7 @@ struct KeyboardSettingsPane: View {
                 }
             }
             .labelsHidden()
+            .accessibilityLabel(title)
             .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
         }
     }
@@ -336,6 +350,7 @@ struct KeyboardSettingsPane: View {
                 }
             }
             .labelsHidden()
+            .accessibilityLabel(L10n.KeyboardVisualizer.styleLabel)
             .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
         }
     }
@@ -348,6 +363,7 @@ struct KeyboardSettingsPane: View {
                 .tag(KeyboardVisualizerStackAxis.horizontal)
         }
         .labelsHidden()
+        .accessibilityLabel(L10n.KeyboardVisualizer.axisLabel)
         .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
     }
 

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/KeyboardVisualizerAnchorPicker.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/KeyboardVisualizerAnchorPicker.swift
@@ -10,6 +10,12 @@ import SwiftUI
 
 struct KeyboardVisualizerAnchorPicker: View {
     @Binding var selection: KeyboardVisualizerAnchor
+    let accessibilityLabel: String
+
+    init(selection: Binding<KeyboardVisualizerAnchor>, accessibilityLabel: String) {
+        self._selection = selection
+        self.accessibilityLabel = accessibilityLabel
+    }
 
     var body: some View {
         Picker("", selection: self.$selection) {
@@ -18,6 +24,7 @@ struct KeyboardVisualizerAnchorPicker: View {
             }
         }
         .labelsHidden()
+        .accessibilityLabel(self.accessibilityLabel)
         .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PointerIconSettings.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PointerIconSettings.swift
@@ -15,6 +15,7 @@ extension MouseSettingsPane {
             SettingsControlRow(title: L10n.Mouse.enabled, subtitle: L10n.Mouse.pointerIconEnabledSubtitle) {
                 Toggle("", isOn: self.$model.iconEnabled)
                     .labelsHidden()
+                    .accessibilityLabel(L10n.Mouse.enabled)
                     .toggleStyle(.switch)
                     .controlSize(.small)
             }
@@ -24,6 +25,7 @@ extension MouseSettingsPane {
             SettingsControlRow(title: L10n.Mouse.pointerIconAlwaysVisibleLabel, subtitle: L10n.Mouse.pointerIconAlwaysVisibleSubtitle) {
                 Toggle("", isOn: self.$model.iconAlwaysVisible)
                     .labelsHidden()
+                    .accessibilityLabel(L10n.Mouse.pointerIconAlwaysVisibleLabel)
                     .toggleStyle(.switch)
                     .controlSize(.small)
                     .disabled(!self.model.iconEnabled)
@@ -38,6 +40,7 @@ extension MouseSettingsPane {
                     }
                 }
                 .labelsHidden()
+                .accessibilityLabel(L10n.Mouse.pointerIconAnchorLabel)
                 .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
                 .disabled(!self.model.iconEnabled)
             }
@@ -47,6 +50,7 @@ extension MouseSettingsPane {
             SettingsControlRow(title: L10n.Mouse.pointerIconOffsetLabel, subtitle: L10n.Mouse.pointerIconOffsetSubtitle) {
                 Slider(value: self.$model.iconOffset, in: 0...80)
                     .frame(width: Spacing.grid(42))
+                    .accessibilityLabel(L10n.Mouse.pointerIconOffsetLabel)
                     .disabled(!self.model.iconEnabled)
             }
 
@@ -55,6 +59,7 @@ extension MouseSettingsPane {
             SettingsControlRow(title: L10n.Mouse.iconSizeLabel, subtitle: L10n.Mouse.iconSizeSubtitle) {
                 Slider(value: self.$model.iconSizeIndex, in: 0...9, step: 1)
                     .frame(width: Spacing.grid(42))
+                    .accessibilityLabel(L10n.Mouse.iconSizeLabel)
                     .disabled(!self.model.iconEnabled)
             }
 
@@ -90,7 +95,8 @@ extension MouseSettingsPane {
             ),
             sections: MouseSettingsPaneViewModel.ColorPreset.iconBackgroundColorSections,
             currentColor: self.model.iconBackgroundColor,
-            customSelectionID: MouseSettingsPaneViewModel.customIconBackgroundColorSelectionID
+            customSelectionID: MouseSettingsPaneViewModel.customIconBackgroundColorSelectionID,
+            accessibilityLabel: L10n.Mouse.iconBackgroundLabel
         )
     }
 
@@ -110,7 +116,8 @@ extension MouseSettingsPane {
             ),
             sections: MouseSettingsPaneViewModel.ColorPreset.iconTintColorSections,
             currentColor: self.model.iconTintColor,
-            customSelectionID: MouseSettingsPaneViewModel.customIconTintColorSelectionID
+            customSelectionID: MouseSettingsPaneViewModel.customIconTintColorSelectionID,
+            accessibilityLabel: L10n.Mouse.iconTintLabel
         )
     }
 
@@ -118,7 +125,8 @@ extension MouseSettingsPane {
         selection: Binding<String>,
         sections: [[MouseSettingsPaneViewModel.ColorPreset]],
         currentColor: NSColor,
-        customSelectionID: String
+        customSelectionID: String,
+        accessibilityLabel: String
     ) -> some View {
         Picker("", selection: selection) {
             ForEach(Array(sections.enumerated()), id: \.offset) { index, section in
@@ -144,6 +152,7 @@ extension MouseSettingsPane {
             )
         }
         .labelsHidden()
+        .accessibilityLabel(accessibilityLabel)
         .pickerStyle(.menu)
         .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
     }

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PointerRingSettings.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PointerRingSettings.swift
@@ -14,6 +14,7 @@ extension MouseSettingsPane {
             SettingsControlRow(title: L10n.Mouse.enabled, subtitle: L10n.Mouse.enabledSubtitle) {
                 Toggle("", isOn: self.$model.ringEnabled)
                     .labelsHidden()
+                    .accessibilityLabel(L10n.Mouse.enabled)
                     .toggleStyle(.switch)
                     .controlSize(.small)
             }
@@ -23,6 +24,7 @@ extension MouseSettingsPane {
             SettingsControlRow(title: L10n.Mouse.alwaysVisibleLabel, subtitle: L10n.Mouse.alwaysVisibleSubtitle) {
                 Toggle("", isOn: self.$model.ringAlwaysVisible)
                     .labelsHidden()
+                    .accessibilityLabel(L10n.Mouse.alwaysVisibleLabel)
                     .toggleStyle(.switch)
                     .controlSize(.small)
                     .disabled(!self.model.ringEnabled)
@@ -37,6 +39,7 @@ extension MouseSettingsPane {
                     }
                 }
                 .labelsHidden()
+                .accessibilityLabel(L10n.Mouse.ringShapeLabel)
                 .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
                 .disabled(!self.model.ringEnabled)
             }
@@ -57,6 +60,7 @@ extension MouseSettingsPane {
                     step: MouseSettingsPaneViewModel.ringSizeStep
                 )
                     .frame(width: Spacing.grid(42))
+                    .accessibilityLabel(L10n.Mouse.ringSizeLabel)
                     .disabled(!self.model.ringEnabled)
             }
 
@@ -69,6 +73,7 @@ extension MouseSettingsPane {
                     step: MouseSettingsPaneViewModel.ringThicknessStep
                 )
                     .frame(width: Spacing.grid(42))
+                    .accessibilityLabel(L10n.Mouse.ringThicknessLabel)
                     .disabled(!self.model.ringEnabled)
             }
         }
@@ -117,6 +122,7 @@ extension MouseSettingsPane {
             }
         }
         .labelsHidden()
+        .accessibilityLabel(L10n.Mouse.ringColorLabel)
         .pickerStyle(.menu)
         .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
         .onAppear {

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsFormRows.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsFormRows.swift
@@ -101,19 +101,22 @@ struct SettingsSliderControl: View {
     let step: Double?
     let width: CGFloat
     let edgeLabels: SettingsSliderEdgeLabels?
+    let accessibilityLabel: String
 
     init(
         value: Binding<Double>,
         range: ClosedRange<Double>,
         step: Double? = nil,
         width: CGFloat = Spacing.grid(44),
-        edgeLabels: SettingsSliderEdgeLabels? = nil
+        edgeLabels: SettingsSliderEdgeLabels? = nil,
+        accessibilityLabel: String
     ) {
         self._value = value
         self.range = range
         self.step = step
         self.width = width
         self.edgeLabels = edgeLabels
+        self.accessibilityLabel = accessibilityLabel
     }
 
     var body: some View {
@@ -126,6 +129,7 @@ struct SettingsSliderControl: View {
                 }
             }
             .frame(width: self.width)
+            .accessibilityLabel(self.accessibilityLabel)
 
             if let edgeLabels = self.edgeLabels {
                 HStack(spacing: Spacing.none) {

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Update/UpdateSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Update/UpdateSettingsPane.swift
@@ -25,6 +25,7 @@ struct UpdateSettingsPane: View {
                 ) {
                     Toggle("", isOn: $model.automaticallyChecksForUpdates)
                         .labelsHidden()
+                        .accessibilityLabel(L10n.Update.checkAtStartup)
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }
@@ -37,6 +38,7 @@ struct UpdateSettingsPane: View {
                 ) {
                     Toggle("", isOn: $model.sendsSystemProfile)
                         .labelsHidden()
+                        .accessibilityLabel(L10n.Update.includeSystemProfile)
                         .toggleStyle(.switch)
                         .controlSize(.small)
                         .disabled(!model.automaticallyChecksForUpdates)


### PR DESCRIPTION
## Summary

Added explicit accessibility labels to hidden-label controls in Settings so assistive technologies can identify switches, pickers, sliders, and steppers by their visible row titles.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination "platform=macOS"`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Improved Settings accessibility labels for hidden-label controls.