### PR TITLE
fix(settings): cancel mouse preview animation tasks

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PreviewCard.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PreviewCard.swift
@@ -15,9 +15,9 @@ extension MouseSettingsPane {
         private static let idleDuration: TimeInterval = 0.82
 
         @ObservedObject var model: MouseSettingsPaneViewModel
-        @State private var ringPreviewAnimationID = UUID()
+        @State private var ringPreviewTask: Task<Void, Never>?
         @State private var ringPreviewAnimationState = PointerRingAnimation.VisualState.idle(alwaysVisible: false)
-        @State private var iconPreviewAnimationID = UUID()
+        @State private var iconPreviewTask: Task<Void, Never>?
         @State private var iconPreviewVisualState = PointerIconContentView.VisualState.idle
 
         var body: some View {
@@ -207,46 +207,39 @@ private extension MouseSettingsPane.PreviewCard {
     }
 
     func startRingPreviewAnimation() {
-        let animationID = UUID()
-        self.ringPreviewAnimationID = animationID
+        self.ringPreviewTask?.cancel()
         self.ringPreviewAnimationState = .idle(alwaysVisible: self.model.ringAlwaysVisible)
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.idleDuration / 2) {
-            self.runRingPreviewAnimationCycle(animationID)
+        self.ringPreviewTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: (Self.idleDuration / 2).nanoseconds)
+            await self.runRingPreviewAnimationLoop()
         }
     }
 
     func stopRingPreviewAnimation() {
-        self.ringPreviewAnimationID = UUID()
+        self.ringPreviewTask?.cancel()
+        self.ringPreviewTask = nil
         self.ringPreviewAnimationState = .idle(alwaysVisible: self.model.ringAlwaysVisible)
     }
 
-    func runRingPreviewAnimationCycle(_ animationID: UUID) {
-        guard self.canContinueRingPreviewAnimation(animationID) else {
-            return
-        }
-
-        withAnimation(.easeOut(duration: PointerRingAnimation.pressAnimationDuration)) {
-            self.ringPreviewAnimationState = .pressed
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.holdDuration) {
-            guard self.canContinueRingPreviewAnimation(animationID) else {
-                return
+    func runRingPreviewAnimationLoop() async {
+        while self.canContinueRingPreviewAnimation {
+            withAnimation(.easeOut(duration: PointerRingAnimation.pressAnimationDuration)) {
+                self.ringPreviewAnimationState = .pressed
             }
+
+            try? await Task.sleep(nanoseconds: Self.holdDuration.nanoseconds)
+            guard self.canContinueRingPreviewAnimation else { return }
 
             withAnimation(.easeOut(duration: PointerRingAnimation.releaseAnimationDuration)) {
                 self.ringPreviewAnimationState = .released(alwaysVisible: self.model.ringAlwaysVisible)
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.idleDuration) {
-                self.runRingPreviewAnimationCycle(animationID)
-            }
+            try? await Task.sleep(nanoseconds: Self.idleDuration.nanoseconds)
         }
     }
 
-    func canContinueRingPreviewAnimation(_ animationID: UUID) -> Bool {
-        self.ringPreviewAnimationID == animationID && self.model.selectedSettingsTab == .ring
+    var canContinueRingPreviewAnimation: Bool {
+        !Task.isCancelled && self.model.selectedSettingsTab == .ring
     }
 
     func updateIconPreviewAnimation() {
@@ -258,55 +251,40 @@ private extension MouseSettingsPane.PreviewCard {
     }
 
     func startIconPreviewAnimation() {
-        let animationID = UUID()
-        self.iconPreviewAnimationID = animationID
+        self.iconPreviewTask?.cancel()
         self.iconPreviewVisualState = .idle
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + Self.idleDuration / 2) {
-            self.runIconPreviewAnimationCycle(animationID)
+        self.iconPreviewTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: (Self.idleDuration / 2).nanoseconds)
+            await self.runIconPreviewAnimationLoop()
         }
     }
 
     func stopIconPreviewAnimation() {
-        self.iconPreviewAnimationID = UUID()
+        self.iconPreviewTask?.cancel()
+        self.iconPreviewTask = nil
         self.iconPreviewVisualState = .idle
     }
 
-    func runIconPreviewAnimationCycle(_ animationID: UUID) {
-        self.runIconPreviewEvent(at: 0, animationID: animationID)
-    }
+    func runIconPreviewAnimationLoop() async {
+        while self.canContinueIconPreviewAnimation {
+            for event in PreviewIconEvent.allCases {
+                guard self.canContinueIconPreviewAnimation else { return }
+                self.iconPreviewVisualState = event.visualState
 
-    func runIconPreviewEvent(at index: Int, animationID: UUID) {
-        guard self.canContinueIconPreviewAnimation(animationID) else {
-            return
-        }
+                try? await Task.sleep(nanoseconds: event.duration.nanoseconds)
+                guard self.canContinueIconPreviewAnimation else { return }
 
-        guard index < PreviewIconEvent.allCases.count else {
+                self.iconPreviewVisualState = .idle
+
+                try? await Task.sleep(nanoseconds: Self.idleDuration.nanoseconds)
+            }
             self.iconPreviewVisualState = .idle
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.idleDuration) {
-                self.runIconPreviewAnimationCycle(animationID)
-            }
-            return
-        }
-
-        let event = PreviewIconEvent.allCases[index]
-        self.iconPreviewVisualState = event.visualState
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + event.duration) {
-            guard self.canContinueIconPreviewAnimation(animationID) else {
-                return
-            }
-
-            self.iconPreviewVisualState = .idle
-
-            DispatchQueue.main.asyncAfter(deadline: .now() + Self.idleDuration) {
-                self.runIconPreviewEvent(at: index + 1, animationID: animationID)
-            }
+            try? await Task.sleep(nanoseconds: Self.idleDuration.nanoseconds)
         }
     }
 
-    func canContinueIconPreviewAnimation(_ animationID: UUID) -> Bool {
-        self.iconPreviewAnimationID == animationID && self.model.selectedSettingsTab == .icon
+    var canContinueIconPreviewAnimation: Bool {
+        !Task.isCancelled && self.model.selectedSettingsTab == .icon
     }
 }
 

--- a/Apps/Keyty/Sources/Keyty/Support/Extensions/Foundation/TimeInterval+Nanoseconds.swift
+++ b/Apps/Keyty/Sources/Keyty/Support/Extensions/Foundation/TimeInterval+Nanoseconds.swift
@@ -1,0 +1,15 @@
+//
+//  TimeInterval+Nanoseconds.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Foundation
+
+extension TimeInterval {
+    var nanoseconds: UInt64 {
+        UInt64((self * 1_000_000_000).rounded())
+    }
+}

--- a/Apps/Keyty/Tests/KeytyTests/Support/Extensions/Foundation/TimeIntervalNanosecondsTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Support/Extensions/Foundation/TimeIntervalNanosecondsTests.swift
@@ -1,0 +1,24 @@
+//
+//  TimeIntervalNanosecondsTests.swift
+//  KeytyTests
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import XCTest
+@testable import Keyty
+
+final class TimeIntervalNanosecondsTests: XCTestCase {
+    func test_nanoseconds_convertsSecondsToNanoseconds() {
+        XCTAssertEqual(TimeInterval(1).nanoseconds, 1_000_000_000)
+    }
+
+    func test_nanoseconds_convertsFractionalSecondsToNanoseconds() {
+        XCTAssertEqual(TimeInterval(0.82).nanoseconds, 820_000_000)
+    }
+
+    func test_nanoseconds_roundsToNearestNanosecond() {
+        XCTAssertEqual(TimeInterval(0.000_000_001_5).nanoseconds, 2)
+    }
+}


### PR DESCRIPTION
## Summary

Replace the recursive `DispatchQueue.main.asyncAfter` preview loops with cancellable `Task`-based animation loops.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug`
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/TimeIntervalNanosecondsTests`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A
