### PR TITLE
docs(agents): clarify apple type extension guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Run `tuist generate` after changing `Project.swift`, dependencies, build setting
 - New Swift source files should use the existing file header with BSD-3-Clause SPDX metadata.
 - Keep app composition under `App/Composition`; keep platform APIs under `Platform`; keep transformation, formatting, settings, shortcuts, and presence logic under `Services`; keep domain models under `Domain`.
 - Prefer existing helpers and extensions before adding new abstractions.
+- For reusable helpers on Apple types that are not project-specific, prefer shared Foundation/AppKit extensions, such as `TimeInterval.nanoseconds`, instead of private helpers in feature views.
 - Avoid broad refactors unless they are necessary for the requested change.
 
 ## UI and Presentation


### PR DESCRIPTION
## Summary

Clarify the agent coding guidance for reusable helpers on Apple-provided types.

The new guideline directs generic helpers, such as `TimeInterval.nanoseconds`, into shared Foundation/AppKit extensions instead of leaving them as private helpers inside feature views.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Not run; documentation-only change.

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
