### PR TITLE
docs(agents): require pull request template usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Run `tuist generate` after changing `Project.swift`, dependencies, build setting
 - Use Conventional Commits for commit messages and branch names.
 - Branch names should follow `<type>/<short-description>`, for example `fix/menu-bar-position` or `feat/input-overlay-theme`.
 - Commit messages should follow `<type>(<scope>): <description>` when a scope is useful, for example `fix(settings): clamp overlay opacity`.
+- When creating a pull request, always use the existing GitHub pull request template.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Add an agent workflow instruction requiring pull requests to use the repository's existing GitHub pull request template.

This keeps future agent-created PRs aligned with the project review format.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Not run; documentation-only change.

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
