### PR TITLE
refactor(tests): centralize event transformer fixtures

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Domain/Keyboard/KeyboardKeyCode.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Keyboard/KeyboardKeyCode.swift
@@ -17,8 +17,12 @@ enum KeyboardKeyCode: UInt16 {
     // MARK: - Letters & punctuation
 
     case a = 0x00
-    case k = 0x28
+    case e = 0x0E
+    case digit7 = 0x1A
     case minus = 0x1B
+    case u = 0x20
+    case k = 0x28
+    case grave = 0x32
 
     // MARK: - Whitespace & editing
 

--- a/Apps/Keyty/Sources/Keyty/Platform/Capture/EventTap/EventTap.swift
+++ b/Apps/Keyty/Sources/Keyty/Platform/Capture/EventTap/EventTap.swift
@@ -108,7 +108,7 @@ final class EventTap {
     }
 
     fileprivate func handleFlagsChanged(_ cgEvent: CGEvent) {
-        let flags = NSEvent.ModifierFlags(rawValue: UInt(cgEvent.flags.rawValue))
+        let flags = NSEvent.ModifierFlags(cgEventFlags: cgEvent.flags)
         self.delegate?.eventTap(self, noteFlagsChanged: flags)
     }
 

--- a/Apps/Keyty/Sources/Keyty/Support/Extensions/AppKit/NSEventModifierFlags+RawMasks.swift
+++ b/Apps/Keyty/Sources/Keyty/Support/Extensions/AppKit/NSEventModifierFlags+RawMasks.swift
@@ -1,0 +1,23 @@
+//
+//  NSEventModifierFlags+RawMasks.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import AppKit
+
+extension NSEvent.ModifierFlags {
+    init(cgEventFlags: CGEventFlags) {
+        self.init(rawValue: UInt(cgEventFlags.rawValue))
+    }
+
+    func addingRawMasks(_ masks: UInt...) -> Self {
+        self.addingRawMasks(masks)
+    }
+
+    func addingRawMasks(_ masks: [UInt]) -> Self {
+        Self(rawValue: masks.reduce(self.rawValue) { $0 | $1 })
+    }
+}

--- a/Apps/Keyty/Tests/KeytyTests/Domain/Events/MouseEventTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Domain/Events/MouseEventTests.swift
@@ -11,10 +11,10 @@ import XCTest
 
 final class MouseEventTests: XCTestCase {
     func testKindClassifiesButtonsAndScrollDirections() {
-        XCTAssertEqual(makeMouseEvent(type: .leftMouseDown, buttonNumber: 0).kind, .leftButton)
-        XCTAssertEqual(makeMouseEvent(type: .rightMouseDown, buttonNumber: 1).kind, .rightButton)
-        XCTAssertEqual(makeMouseEvent(type: .otherMouseDown, buttonNumber: 2).kind, .middleButton)
-        XCTAssertEqual(makeMouseEvent(type: .otherMouseDown, buttonNumber: 3).kind, .otherButton(4))
+        XCTAssertEqual(TestMouseEvents.make(type: .leftMouseDown, buttonNumber: 0).kind, .leftButton)
+        XCTAssertEqual(TestMouseEvents.make(type: .rightMouseDown, buttonNumber: 1).kind, .rightButton)
+        XCTAssertEqual(TestMouseEvents.make(type: .otherMouseDown, buttonNumber: 2).kind, .middleButton)
+        XCTAssertEqual(TestMouseEvents.make(type: .otherMouseDown, buttonNumber: 3).kind, .otherButton(4))
         XCTAssertEqual(makeScrollEvent(deltaX: 0, deltaY: 1).kind, .wheelUp)
         XCTAssertEqual(makeScrollEvent(deltaX: 0, deltaY: -1).kind, .wheelDown)
         XCTAssertEqual(makeScrollEvent(deltaX: -1, deltaY: 0).kind, .wheelLeft)
@@ -66,19 +66,6 @@ final class MouseEventTests: XCTestCase {
 
         XCTAssertEqual(location.x, 1600)
         XCTAssertEqual(location.y, 980)
-    }
-
-    private func makeMouseEvent(type: NSEvent.EventType, buttonNumber: Int) -> MouseEvent {
-        let cgType: CGEventType = {
-            switch type {
-            case .leftMouseDown: return .leftMouseDown
-            case .rightMouseDown: return .rightMouseDown
-            default: return .otherMouseDown
-            }
-        }()
-        let cgEvent = CGEvent(mouseEventSource: nil, mouseType: cgType, mouseCursorPosition: .zero, mouseButton: .left)!
-        cgEvent.setIntegerValueField(.mouseEventButtonNumber, value: Int64(buttonNumber))
-        return MouseEvent(nsEvent: NSEvent(cgEvent: cgEvent)!)
     }
 
     private func makeScrollEvent(deltaX: CGFloat, deltaY: CGFloat) -> MouseEvent {

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSpecialKeyFilteringTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSpecialKeyFilteringTests.swift
@@ -33,7 +33,7 @@ final class KeyboardVisualizerSpecialKeyFilteringTests: XCTestCase {
     }
 
     func testResolverClassifiesInsertFunctionKeyAsSpecial() {
-        let ch = Self.appKitFunctionKey(NSInsertFunctionKey)
+        let ch = TestKeyboardCharacters.functionKeyCharacter(NSInsertFunctionKey)
         let event = Self.makeKeystroke(
             keyCode: KeyboardKeyCode.help.rawValue,
             characters: ch,
@@ -73,7 +73,4 @@ final class KeyboardVisualizerSpecialKeyFilteringTests: XCTestCase {
         return StandardKeyEvent(nsEvent: event)
     }
 
-    private static func appKitFunctionKey(_ key: Int) -> String {
-        String(UnicodeScalar(key)!)
-    }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSpecialKeyFilteringTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSpecialKeyFilteringTests.swift
@@ -34,7 +34,7 @@ final class KeyboardVisualizerSpecialKeyFilteringTests: XCTestCase {
 
     func testResolverClassifiesInsertFunctionKeyAsSpecial() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSInsertFunctionKey)
-        let event = Self.makeKeystroke(
+        let event = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.help.rawValue,
             characters: ch,
             charactersIgnoringModifiers: ch
@@ -44,33 +44,13 @@ final class KeyboardVisualizerSpecialKeyFilteringTests: XCTestCase {
     }
 
     func testResolverClassifiesPrintableLetterAsNonSpecial() {
-        let event = Self.makeKeystroke(
+        let event = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.a.rawValue,
             characters: "a",
             charactersIgnoringModifiers: "a"
         )
 
         XCTAssertFalse(KeyboardSpecialKeyResolver.isSpecial(event))
-    }
-
-    private static func makeKeystroke(
-        keyCode: UInt16,
-        characters: String,
-        charactersIgnoringModifiers: String
-    ) -> StandardKeyEvent {
-        let event = NSEvent.keyEvent(
-            with: .keyDown,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: NSDate.timeIntervalSinceReferenceDate,
-            windowNumber: 0,
-            context: nil,
-            characters: characters,
-            charactersIgnoringModifiers: charactersIgnoringModifiers,
-            isARepeat: false,
-            keyCode: keyCode
-        )!
-        return StandardKeyEvent(nsEvent: event)
     }
 
 }

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
@@ -12,9 +12,8 @@ import XCTest
 
 final class KeycapItemFactoryTests: XCTestCase {
     func testKeyboardModifierKeysDecodeLocationSpecificFlags() {
-        let flags = NSEvent.ModifierFlags(
-            .command,
-            deviceMasks: UInt(NX_DEVICELCMDKEYMASK),
+        let flags = NSEvent.ModifierFlags.command.addingRawMasks(
+            UInt(NX_DEVICELCMDKEYMASK),
             UInt(NX_DEVICERCMDKEYMASK)
         )
 
@@ -37,9 +36,8 @@ final class KeycapItemFactoryTests: XCTestCase {
 
     func testModifierItemsUseLocationSpecificModifierKeys() {
         let items = KeycapItemFactory.modifierItems(
-            currentFlags: NSEvent.ModifierFlags(
-                .command,
-                deviceMasks: UInt(NX_DEVICELCMDKEYMASK),
+            currentFlags: NSEvent.ModifierFlags.command.addingRawMasks(
+                UInt(NX_DEVICELCMDKEYMASK),
                 UInt(NX_DEVICERCMDKEYMASK)
             ),
             releasedFlags: [],
@@ -55,9 +53,8 @@ final class KeycapItemFactoryTests: XCTestCase {
 
     func testModifierItemsUseInwardAlignmentForNonCommandModifierKeys() {
         let items = KeycapItemFactory.modifierItems(
-            currentFlags: NSEvent.ModifierFlags(
-                .shift,
-                deviceMasks: UInt(NX_DEVICELSHIFTKEYMASK),
+            currentFlags: NSEvent.ModifierFlags.shift.addingRawMasks(
+                UInt(NX_DEVICELSHIFTKEYMASK),
                 UInt(NX_DEVICERSHIFTKEYMASK)
             ),
             releasedFlags: [],

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
@@ -134,11 +134,11 @@ final class KeycapItemFactoryTests: XCTestCase {
         let palette = Self.makePalette()
 
         let downItem = KeycapItemFactory.mouseItem(
-            for: Self.makeMouseEvent(type: .leftMouseDown),
+            for: TestMouseEvents.make(type: .leftMouseDown),
             palette: palette
         )
         let upItem = KeycapItemFactory.mouseItem(
-            for: Self.makeMouseEvent(type: .leftMouseUp),
+            for: TestMouseEvents.make(type: .leftMouseUp),
             palette: palette
         )
 
@@ -164,9 +164,4 @@ final class KeycapItemFactoryTests: XCTestCase {
         )
     }
 
-    private static func makeMouseEvent(type: NSEvent.EventType) -> MouseEvent {
-        let cgType: CGEventType = type == .leftMouseDown ? .leftMouseDown : .leftMouseUp
-        let cgEvent = CGEvent(mouseEventSource: nil, mouseType: cgType, mouseCursorPosition: .zero, mouseButton: .left)!
-        return MouseEvent(nsEvent: NSEvent(cgEvent: cgEvent)!)
-    }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
@@ -15,7 +15,7 @@ final class EventProcessorTests: XCTestCase {
         var items: [DisplayItem] = []
         processor.onItemProduced = { items.append($0) }
 
-        processor.noteMouseEvent(Self.makeMouseEvent(type: .leftMouseUp, buttonNumber: 0, modifiers: [.command]))
+        processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: [.command]))
 
         XCTAssertEqual(items.count, 2)
         XCTAssertEqual(items[0].kind, .content)
@@ -28,7 +28,7 @@ final class EventProcessorTests: XCTestCase {
         var items: [DisplayItem] = []
         processor.onItemProduced = { items.append($0) }
 
-        processor.noteMouseEvent(Self.makeMouseEvent(type: .leftMouseUp, buttonNumber: 0, modifiers: []))
+        processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: []))
 
         XCTAssertEqual(items.count, 2)
         XCTAssertEqual(items[0].kind, .content)
@@ -36,29 +36,4 @@ final class EventProcessorTests: XCTestCase {
         XCTAssertEqual(items[1].kind, .groupBreak)
     }
 
-    private static func makeMouseEvent(
-        type: NSEvent.EventType,
-        buttonNumber: Int,
-        modifiers: NSEvent.ModifierFlags
-    ) -> MouseEvent {
-        let cgType: CGEventType = {
-            switch type {
-            case .leftMouseDown, .leftMouseUp: return type == .leftMouseDown ? .leftMouseDown : .leftMouseUp
-            case .rightMouseDown, .rightMouseUp: return type == .rightMouseDown ? .rightMouseDown : .rightMouseUp
-            default: return type == .otherMouseDown ? .otherMouseDown : .otherMouseUp
-            }
-        }()
-
-        var cgFlags: CGEventFlags = []
-        if modifiers.contains(.shift)   { cgFlags.insert(.maskShift) }
-        if modifiers.contains(.command) { cgFlags.insert(.maskCommand) }
-        if modifiers.contains(.control) { cgFlags.insert(.maskControl) }
-        if modifiers.contains(.option)  { cgFlags.insert(.maskAlternate) }
-        if modifiers.contains(.function) { cgFlags.insert(.maskSecondaryFn) }
-
-        let cgEvent = CGEvent(mouseEventSource: nil, mouseType: cgType, mouseCursorPosition: .zero, mouseButton: .left)!
-        cgEvent.setIntegerValueField(.mouseEventButtonNumber, value: Int64(buttonNumber))
-        cgEvent.flags = cgFlags
-        return MouseEvent(nsEvent: NSEvent(cgEvent: cgEvent)!)
-    }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -222,7 +222,7 @@ extension EventTransformerKeystrokeTests {
     func test_insertFunctionKeyDisplaysInsertForHelpKeyCode() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSInsertFunctionKey)
         self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
-        XCTAssertEqual(self.transform(self.keystroke), "ins")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardSpecialKey.insert.displayText)
     }
 
     func test_helpFunctionKeyDisplaysHelpForHelpKeyCode() {
@@ -233,7 +233,7 @@ extension EventTransformerKeystrokeTests {
 
     func test_helpKeyCodeWithoutSemanticCharactersDefaultsToInsert() {
         self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(self.transform(self.keystroke), "ins")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardSpecialKey.insert.displayText)
     }
 }
 

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -16,21 +16,9 @@ import XCTest
 final class EventTransformerKeystrokeTests: XCTestCase {
     var keystroke: StandardKeyEvent!
     var keyboardLayout: TISInputSource!
-    var keyboardLayouts: [TISInputSource] = []
 
     func transform(_ event: StandardKeyEvent) -> String {
         EventTransformer(keyboardLayout: keyboardLayout).transform(.keystroke(event))
-    }
-
-    func usEnglishKeyboardLayout() -> TISInputSource {
-        let properties: [String: Any] = [
-            kTISPropertyInputSourceID as String: "com.apple.keylayout.US",
-            kTISPropertyInputSourceType as String: kTISTypeKeyboardLayout as String
-        ]
-        keyboardLayouts = TISCreateInputSourceList(properties as CFDictionary, true)!
-            .takeRetainedValue() as! [TISInputSource]
-        XCTAssertGreaterThan(keyboardLayouts.count, 0)
-        return keyboardLayouts[0]
     }
 
     func makeKeystroke(keyCode: UInt16, modifiers: NSEvent.ModifierFlags,
@@ -50,9 +38,9 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         return StandardKeyEvent(nsEvent: event)
     }
 
-    override func setUp() {
-        super.setUp()
-        keyboardLayout = usEnglishKeyboardLayout()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        keyboardLayout = try TestKeyboardLayouts.requireUSEnglish()
     }
 
     // MARK: - Numbers

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -246,7 +246,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     // MARK: - US English - Special Cases with Modifiers
 
     func test_optionShiftUp() {
-        let ch = String(format: "%lu", UInt64(0x00006000002f5c00))
+        let ch = Self.appKitFunctionKey(NSUpArrowFunctionKey)
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
 
         XCTAssertEqual(

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -18,176 +18,186 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     var keyboardLayout: TISInputSource!
 
     func transform(_ event: StandardKeyEvent) -> String {
-        EventTransformer(keyboardLayout: keyboardLayout).transform(.keystroke(event))
+        EventTransformer(keyboardLayout: self.keyboardLayout).transform(.keystroke(event))
     }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        keyboardLayout = try TestKeyboardLayouts.requireUSEnglish()
+        self.keyboardLayout = try TestKeyboardLayouts.requireUSEnglish()
     }
+}
 
-    // MARK: - Numbers
+// MARK: - Numbers
 
+extension EventTransformerKeystrokeTests {
     func test_KCKeystroke_convertsCtrlNumberToNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.control, characters: "7", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.control, characters: "7", charactersIgnoringModifiers: "7")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.control + "7")
     }
 
     func test_KCKeystroke_convertsShiftNumberToShiftNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.shift, characters: "&", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.shift + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.shift, characters: "&", charactersIgnoringModifiers: "&")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCtrlShiftNumberToNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.controlShift, characters: "7", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.controlShift, characters: "7", charactersIgnoringModifiers: "&")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCmdNumberToNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.command, characters: "7", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.command + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.command, characters: "7", charactersIgnoringModifiers: "7")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsCmdShiftNumberToNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandShift, characters: "7", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandShift, characters: "7", charactersIgnoringModifiers: "&")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsCmdOptNumberToNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOption, characters: "¶", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.command + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOption, characters: "¶", charactersIgnoringModifiers: "7")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsShiftOptionNumberToNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCmdOptShiftNumberToShiftedNumber() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOptionShift, characters: "‡", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOptionShift, characters: "‡", charactersIgnoringModifiers: "&")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
     }
+}
 
-    // MARK: - Letters
+// MARK: - Letters
 
+extension EventTransformerKeystrokeTests {
     func test_KCKeystroke_convertsCtrlLetterToUppercaseLetter() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.control, characters: "^A", charactersIgnoringModifiers: "a")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + "A")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.control, characters: "^A", charactersIgnoringModifiers: "a")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.control + "A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftLetterToLetter() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlShift, characters: "^A", charactersIgnoringModifiers: "a")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "A")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlShift, characters: "^A", charactersIgnoringModifiers: "a")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftCmdLetterToLetter() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlCommandShift, characters: "^A", charactersIgnoringModifiers: "A")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "A")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlCommandShift, characters: "^A", charactersIgnoringModifiers: "A")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "A")
     }
 
     func test_KCKeystroke_convertsCtrlOptLetterToUppercaseLetter() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOption, characters: "^A", charactersIgnoringModifiers: "a")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + "A")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOption, characters: "^A", charactersIgnoringModifiers: "a")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + "A")
     }
 
     func test_KCKeystroke_convertsCtrlOptShiftLetterToLetter() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOptionShift, characters: "^A", charactersIgnoringModifiers: "A")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "A")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOptionShift, characters: "^A", charactersIgnoringModifiers: "A")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "A")
     }
 
     func test_KCKeystroke_displaysOptLetterByDefault() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "U")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + "U")
     }
+}
 
-    // MARK: - Function Row
-
+// MARK: - Function Row
+extension EventTransformerKeystrokeTests {
     func test_KCKeystroke_convertsFnF1ToBrightnessDecrease() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), UnicodeToken.brightnessDown.string)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.brightnessDown.string)
     }
 
     func test_KCKeystroke_convertsFnF2ToBrightnessIncrease() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), UnicodeToken.brightnessUp.string)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.brightnessUp.string)
     }
 
     func test_KCKeystroke_convertsFnF3ToMissionControl() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), UnicodeToken.missionControl.string)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.missionControl.string)
     }
 
     func test_KCKeystroke_convertsFnF4ToLauncher() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), UnicodeToken.launchpad.string)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.launchpad.string)
     }
+}
 
-    // MARK: - JIS layout
-
+// MARK: - JIS layout
+extension EventTransformerKeystrokeTests {
     func test_KCKeystroke_convertsEisuKey() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.eisu.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), "英数")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.eisu.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        XCTAssertEqual(self.transform(self.keystroke), "英数")
     }
 
     func test_KCKeystroke_convertsKanaKey() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.kana.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), "かな")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.kana.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        XCTAssertEqual(self.transform(self.keystroke), "かな")
     }
+}
 
-    // MARK: - Option-modified characters
+// MARK: - Option-modified characters
 
+extension EventTransformerKeystrokeTests {
     func test_optionShiftNumberDisplaysExplicitModifiers() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
     }
+}
 
-    // MARK: - Special Cases
+// MARK: - Special Cases
 
+extension EventTransformerKeystrokeTests {
     func test_tabKey() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.none, characters: "\t", charactersIgnoringModifiers: "\t")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.tab)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.none, characters: "\t", charactersIgnoringModifiers: "\t")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.tab)
     }
 
     func test_returnAndKeypadEnterUseDifferentSymbols() {
-        keystroke = TestKeystrokes.make(
+        self.keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.returnKey.rawValue,
             modifiers: TestModifierFlags.none,
             characters: "\r",
             charactersIgnoringModifiers: "\r"
         )
-        XCTAssertEqual(transform(keystroke), UnicodeToken.returnKey.string)
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.returnKey.string)
 
-        keystroke = TestKeystrokes.make(
+        self.keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.keypadEnter.rawValue,
             modifiers: TestModifierFlags.none,
             characters: "\r",
             charactersIgnoringModifiers: "\r"
         )
-        XCTAssertEqual(transform(keystroke), UnicodeToken.keypadEnter.string)
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.keypadEnter.string)
     }
 
     func test_deleteAndForwardDeleteUseDifferentSymbols() {
-        keystroke = TestKeystrokes.make(
+        self.keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.delete.rawValue,
             modifiers: TestModifierFlags.none,
             characters: UnicodeToken.delete.string,
             charactersIgnoringModifiers: UnicodeToken.delete.string
         )
-        XCTAssertEqual(transform(keystroke), UnicodeToken.delete.string)
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.delete.string)
 
-        keystroke = TestKeystrokes.make(
+        self.keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.forwardDelete.rawValue,
             modifiers: TestModifierFlags.none,
             characters: UnicodeToken.forwardDelete.string,
             charactersIgnoringModifiers: UnicodeToken.forwardDelete.string
         )
-        XCTAssertEqual(transform(keystroke), UnicodeToken.forwardDelete.string)
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.forwardDelete.string)
     }
 
     func test_shiftTab() {
         let ch = TestKeyboardCharacters.backTab
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.shift, characters: ch, charactersIgnoringModifiers: ch)
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.backTab)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.shift, characters: ch, charactersIgnoringModifiers: ch)
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.backTab)
     }
 
     func test_arrowKeysUseFilledTriangleSymbols() {
@@ -199,65 +209,69 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         ]
 
         for (keyCode, expected) in cases {
-            keystroke = TestKeystrokes.make(
+            self.keystroke = TestKeystrokes.make(
                 keyCode: keyCode.rawValue,
                 modifiers: TestModifierFlags.none,
                 characters: expected,
                 charactersIgnoringModifiers: expected
             )
-            XCTAssertEqual(transform(keystroke), expected)
+            XCTAssertEqual(self.transform(self.keystroke), expected)
         }
     }
 
     func test_insertFunctionKeyDisplaysInsertForHelpKeyCode() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSInsertFunctionKey)
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
-        XCTAssertEqual(transform(keystroke), "ins")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
+        XCTAssertEqual(self.transform(self.keystroke), "ins")
     }
 
     func test_helpFunctionKeyDisplaysHelpForHelpKeyCode() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSHelpFunctionKey)
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
-        XCTAssertEqual(transform(keystroke), UnicodeToken.questionMark.string + UnicodeToken.enclosingCircle.string)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
+        XCTAssertEqual(self.transform(self.keystroke), UnicodeToken.questionMark.string + UnicodeToken.enclosingCircle.string)
     }
 
     func test_helpKeyCodeWithoutSemanticCharactersDefaultsToInsert() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), "ins")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        XCTAssertEqual(self.transform(self.keystroke), "ins")
     }
+}
 
-    // MARK: - US English - Special Cases with Modifiers
+// MARK: - US English - Special Cases with Modifiers
 
+extension EventTransformerKeystrokeTests {
     func test_optionShiftUp() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSUpArrowFunctionKey)
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
 
         XCTAssertEqual(
-            transform(keystroke),
+            self.transform(self.keystroke),
             KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + UnicodeToken.upArrow.string
         )
     }
 
     func test_optionUSpecialCase() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "U")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + "U")
     }
 
     func test_optionESpecialCase() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.e.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "e")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "E")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.e.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "e")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + "E")
     }
 
     func test_optionBacktickSpecialCase() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "`")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "`")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "`")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.option + "`")
     }
+}
 
-    // MARK: - German - Special Case
+// MARK: - German - Special Case
 
+extension EventTransformerKeystrokeTests {
     func test_commandßDisplaysCommandß() {
-        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: TestModifierFlags.command, characters: "ß", charactersIgnoringModifiers: "ß")
-        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.command + "ß")
+        self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: TestModifierFlags.command, characters: "ß", charactersIgnoringModifiers: "ß")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardGlyphCatalog.command + "ß")
     }
 
 }

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -58,122 +58,122 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     // MARK: - Numbers
 
     func test_KCKeystroke_convertsCtrlNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 262401), characters: "7", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 262401), characters: "7", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌃7")
     }
 
     func test_KCKeystroke_convertsShiftNumberToShiftNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 131330), characters: "&", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 131330), characters: "&", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⇧7")
     }
 
     func test_KCKeystroke_convertsCtrlShiftNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 393475), characters: "7", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 393475), characters: "7", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⌃⇧7")
     }
 
     func test_KCKeystroke_convertsCmdNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 1048840), characters: "7", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1048840), characters: "7", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌘7")
     }
 
     func test_KCKeystroke_convertsCmdShiftNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 1179914), characters: "7", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1179914), characters: "7", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⇧⌘7")
     }
 
     func test_KCKeystroke_convertsCmdOptNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 1573160), characters: "¶", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1573160), characters: "¶", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌥⌘7")
     }
 
     func test_KCKeystroke_convertsShiftOptionNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 655650), characters: "»", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 655650), characters: "»", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌥⇧7")
     }
 
     func test_KCKeystroke_convertsCmdOptShiftNumberToShiftedNumber() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 1704234), characters: "‡", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1704234), characters: "‡", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⌥⇧⌘7")
     }
 
     // MARK: - Letters
 
     func test_KCKeystroke_convertsCtrlLetterToUppercaseLetter() {
-        keystroke = makeKeystroke(keyCode: 0, modifiers: NSEvent.ModifierFlags(rawValue: 262401), characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 262401), characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), "⌃A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: 0, modifiers: NSEvent.ModifierFlags(rawValue: 393475), characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 393475), characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), "⌃⇧A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftCmdLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: 0, modifiers: NSEvent.ModifierFlags(rawValue: 1442059), characters: "^A", charactersIgnoringModifiers: "A")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1442059), characters: "^A", charactersIgnoringModifiers: "A")
         XCTAssertEqual(transform(keystroke), "⌃⇧⌘A")
     }
 
     func test_KCKeystroke_convertsCtrlOptLetterToUppercaseLetter() {
-        keystroke = makeKeystroke(keyCode: 0, modifiers: NSEvent.ModifierFlags(rawValue: 786721), characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 786721), characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), "⌃⌥A")
     }
 
     func test_KCKeystroke_convertsCtrlOptShiftLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: 0, modifiers: NSEvent.ModifierFlags(rawValue: 917795), characters: "^A", charactersIgnoringModifiers: "A")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 917795), characters: "^A", charactersIgnoringModifiers: "A")
         XCTAssertEqual(transform(keystroke), "⌃⌥⇧A")
     }
 
     func test_KCKeystroke_displaysOptLetterByDefault() {
-        keystroke = makeKeystroke(keyCode: 32, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "u")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "u")
         XCTAssertEqual(transform(keystroke), "⌥U")
     }
 
     // MARK: - Function Row
 
     func test_KCKeystroke_convertsFnF1ToBrightnessDecrease() {
-        keystroke = makeKeystroke(keyCode: 145, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🔅")
     }
 
     func test_KCKeystroke_convertsFnF2ToBrightnessIncrease() {
-        keystroke = makeKeystroke(keyCode: 144, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🔆")
     }
 
     func test_KCKeystroke_convertsFnF3ToMissionControl() {
-        keystroke = makeKeystroke(keyCode: 160, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🖥")
     }
 
     func test_KCKeystroke_convertsFnF4ToLauncher() {
-        keystroke = makeKeystroke(keyCode: 131, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🚀")
     }
 
     // MARK: - JIS layout
 
     func test_KCKeystroke_convertsEisuKey() {
-        keystroke = makeKeystroke(keyCode: 102, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.eisu.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "英数")
     }
 
     func test_KCKeystroke_convertsKanaKey() {
-        keystroke = makeKeystroke(keyCode: 104, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.kana.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "かな")
     }
 
     // MARK: - Option-modified characters
 
     func test_optionShiftNumberDisplaysExplicitModifiers() {
-        keystroke = makeKeystroke(keyCode: 26, modifiers: NSEvent.ModifierFlags(rawValue: 655650), characters: "»", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 655650), characters: "»", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌥⇧7")
     }
 
     // MARK: - Special Cases
 
     func test_tabKey() {
-        keystroke = makeKeystroke(keyCode: 48, modifiers: NSEvent.ModifierFlags(rawValue: 256), characters: "\t", charactersIgnoringModifiers: "\t")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 256), characters: "\t", charactersIgnoringModifiers: "\t")
         XCTAssertEqual(transform(keystroke), "⇥")
     }
 
@@ -215,7 +215,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_shiftTab() {
         let ch = String(UnicodeScalar(0x19)!)
-        keystroke = makeKeystroke(keyCode: 48, modifiers: NSEvent.ModifierFlags(rawValue: 131330), characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 131330), characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), "⇤")
     }
 
@@ -259,30 +259,30 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_optionShiftUp() {
         let ch = String(format: "%lu", UInt64(0x00006000002f5c00))
-        keystroke = makeKeystroke(keyCode: 126, modifiers: NSEvent.ModifierFlags(rawValue: 11141410), characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 11141410), characters: ch, charactersIgnoringModifiers: ch)
 
         XCTAssertEqual(transform(keystroke), "⌥⇧▲")
     }
 
     func test_optionUSpecialCase() {
-        keystroke = makeKeystroke(keyCode: 32, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "u")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "u")
         XCTAssertEqual(transform(keystroke), "⌥U")
     }
 
     func test_optionESpecialCase() {
-        keystroke = makeKeystroke(keyCode: 14, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "e")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.e.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "e")
         XCTAssertEqual(transform(keystroke), "⌥E")
     }
 
     func test_optionBacktickSpecialCase() {
-        keystroke = makeKeystroke(keyCode: 50, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "`")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "`")
         XCTAssertEqual(transform(keystroke), "⌥`")
     }
 
     // MARK: - German - Special Case
 
     func test_commandßDisplaysCommandß() {
-        keystroke = makeKeystroke(keyCode: 27, modifiers: NSEvent.ModifierFlags(rawValue: 1048840), characters: "ß", charactersIgnoringModifiers: "ß")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1048840), characters: "ß", charactersIgnoringModifiers: "ß")
         XCTAssertEqual(transform(keystroke), "⌘ß")
     }
 

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -47,96 +47,96 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_KCKeystroke_convertsCtrlNumberToNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.control, characters: "7", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), "⌃7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + "7")
     }
 
     func test_KCKeystroke_convertsShiftNumberToShiftNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.shift, characters: "&", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), "⇧7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCtrlShiftNumberToNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.controlShift, characters: "7", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), "⌃⇧7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCmdNumberToNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.command, characters: "7", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), "⌘7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsCmdShiftNumberToNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandShift, characters: "7", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), "⇧⌘7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsCmdOptNumberToNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOption, characters: "¶", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), "⌥⌘7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsShiftOptionNumberToNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), "⌥⇧7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCmdOptShiftNumberToShiftedNumber() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOptionShift, characters: "‡", charactersIgnoringModifiers: "&")
-        XCTAssertEqual(transform(keystroke), "⌥⇧⌘7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
     }
 
     // MARK: - Letters
 
     func test_KCKeystroke_convertsCtrlLetterToUppercaseLetter() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.control, characters: "^A", charactersIgnoringModifiers: "a")
-        XCTAssertEqual(transform(keystroke), "⌃A")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + "A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftLetterToLetter() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlShift, characters: "^A", charactersIgnoringModifiers: "a")
-        XCTAssertEqual(transform(keystroke), "⌃⇧A")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftCmdLetterToLetter() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlCommandShift, characters: "^A", charactersIgnoringModifiers: "A")
-        XCTAssertEqual(transform(keystroke), "⌃⇧⌘A")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "A")
     }
 
     func test_KCKeystroke_convertsCtrlOptLetterToUppercaseLetter() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOption, characters: "^A", charactersIgnoringModifiers: "a")
-        XCTAssertEqual(transform(keystroke), "⌃⌥A")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + "A")
     }
 
     func test_KCKeystroke_convertsCtrlOptShiftLetterToLetter() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOptionShift, characters: "^A", charactersIgnoringModifiers: "A")
-        XCTAssertEqual(transform(keystroke), "⌃⌥⇧A")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "A")
     }
 
     func test_KCKeystroke_displaysOptLetterByDefault() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
-        XCTAssertEqual(transform(keystroke), "⌥U")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "U")
     }
 
     // MARK: - Function Row
 
     func test_KCKeystroke_convertsFnF1ToBrightnessDecrease() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), "🔅")
+        XCTAssertEqual(transform(keystroke), UnicodeToken.brightnessDown.string)
     }
 
     func test_KCKeystroke_convertsFnF2ToBrightnessIncrease() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), "🔆")
+        XCTAssertEqual(transform(keystroke), UnicodeToken.brightnessUp.string)
     }
 
     func test_KCKeystroke_convertsFnF3ToMissionControl() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), "🖥")
+        XCTAssertEqual(transform(keystroke), UnicodeToken.missionControl.string)
     }
 
     func test_KCKeystroke_convertsFnF4ToLauncher() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(transform(keystroke), "🚀")
+        XCTAssertEqual(transform(keystroke), UnicodeToken.launchpad.string)
     }
 
     // MARK: - JIS layout
@@ -155,14 +155,14 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_optionShiftNumberDisplaysExplicitModifiers() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
-        XCTAssertEqual(transform(keystroke), "⌥⇧7")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
     }
 
     // MARK: - Special Cases
 
     func test_tabKey() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.none, characters: "\t", charactersIgnoringModifiers: "\t")
-        XCTAssertEqual(transform(keystroke), "⇥")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.tab)
     }
 
     func test_returnAndKeypadEnterUseDifferentSymbols() {
@@ -204,15 +204,15 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     func test_shiftTab() {
         let ch = String(UnicodeScalar(0x19)!)
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.shift, characters: ch, charactersIgnoringModifiers: ch)
-        XCTAssertEqual(transform(keystroke), "⇤")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.backTab)
     }
 
     func test_arrowKeysUseFilledTriangleSymbols() {
         let cases: [(KeyboardKeyCode, String)] = [
-            (.leftArrow, "◀"),
-            (.upArrow, "▲"),
-            (.downArrow, "▼"),
-            (.rightArrow, "▶")
+            (.leftArrow, UnicodeToken.leftArrow.string),
+            (.upArrow, UnicodeToken.upArrow.string),
+            (.downArrow, UnicodeToken.downArrow.string),
+            (.rightArrow, UnicodeToken.rightArrow.string)
         ]
 
         for (keyCode, expected) in cases {
@@ -249,29 +249,32 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         let ch = String(format: "%lu", UInt64(0x00006000002f5c00))
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
 
-        XCTAssertEqual(transform(keystroke), "⌥⇧▲")
+        XCTAssertEqual(
+            transform(keystroke),
+            KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + UnicodeToken.upArrow.string
+        )
     }
 
     func test_optionUSpecialCase() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
-        XCTAssertEqual(transform(keystroke), "⌥U")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "U")
     }
 
     func test_optionESpecialCase() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.e.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "e")
-        XCTAssertEqual(transform(keystroke), "⌥E")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "E")
     }
 
     func test_optionBacktickSpecialCase() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "`")
-        XCTAssertEqual(transform(keystroke), "⌥`")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "`")
     }
 
     // MARK: - German - Special Case
 
     func test_commandßDisplaysCommandß() {
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: TestModifierFlags.command, characters: "ß", charactersIgnoringModifiers: "ß")
-        XCTAssertEqual(transform(keystroke), "⌘ß")
+        XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.command + "ß")
     }
 
     private static func appKitFunctionKey(_ key: Int) -> String {

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -132,12 +132,12 @@ extension EventTransformerKeystrokeTests {
 extension EventTransformerKeystrokeTests {
     func test_KCKeystroke_convertsEisuKey() {
         self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.eisu.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(self.transform(self.keystroke), "英数")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardSpecialKey.eisu.displayText)
     }
 
     func test_KCKeystroke_convertsKanaKey() {
         self.keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.kana.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(self.transform(self.keystroke), "かな")
+        XCTAssertEqual(self.transform(self.keystroke), KeyboardSpecialKey.kana.displayText)
     }
 }
 

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -21,23 +21,6 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         EventTransformer(keyboardLayout: keyboardLayout).transform(.keystroke(event))
     }
 
-    func makeKeystroke(keyCode: UInt16, modifiers: NSEvent.ModifierFlags,
-                       characters: String, charactersIgnoringModifiers: String) -> StandardKeyEvent {
-        let event = NSEvent.keyEvent(
-            with: .keyDown,
-            location: .zero,
-            modifierFlags: modifiers,
-            timestamp: NSDate.timeIntervalSinceReferenceDate,
-            windowNumber: 0,
-            context: nil,
-            characters: characters,
-            charactersIgnoringModifiers: charactersIgnoringModifiers,
-            isARepeat: false,
-            keyCode: keyCode
-        )!
-        return StandardKeyEvent(nsEvent: event)
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
         keyboardLayout = try TestKeyboardLayouts.requireUSEnglish()
@@ -46,127 +29,127 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     // MARK: - Numbers
 
     func test_KCKeystroke_convertsCtrlNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.control, characters: "7", charactersIgnoringModifiers: "7")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.control, characters: "7", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + "7")
     }
 
     func test_KCKeystroke_convertsShiftNumberToShiftNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.shift, characters: "&", charactersIgnoringModifiers: "&")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.shift, characters: "&", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCtrlShiftNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.controlShift, characters: "7", charactersIgnoringModifiers: "&")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.controlShift, characters: "7", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCmdNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.command, characters: "7", charactersIgnoringModifiers: "7")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.command, characters: "7", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsCmdShiftNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandShift, characters: "7", charactersIgnoringModifiers: "&")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandShift, characters: "7", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsCmdOptNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOption, characters: "¶", charactersIgnoringModifiers: "7")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOption, characters: "¶", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.command + "7")
     }
 
     func test_KCKeystroke_convertsShiftOptionNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
     }
 
     func test_KCKeystroke_convertsCmdOptShiftNumberToShiftedNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOptionShift, characters: "‡", charactersIgnoringModifiers: "&")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOptionShift, characters: "‡", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "7")
     }
 
     // MARK: - Letters
 
     func test_KCKeystroke_convertsCtrlLetterToUppercaseLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.control, characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.control, characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + "A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlShift, characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlShift, characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + "A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftCmdLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlCommandShift, characters: "^A", charactersIgnoringModifiers: "A")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlCommandShift, characters: "^A", charactersIgnoringModifiers: "A")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.shift + KeyboardGlyphCatalog.command + "A")
     }
 
     func test_KCKeystroke_convertsCtrlOptLetterToUppercaseLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOption, characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOption, characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + "A")
     }
 
     func test_KCKeystroke_convertsCtrlOptShiftLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOptionShift, characters: "^A", charactersIgnoringModifiers: "A")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOptionShift, characters: "^A", charactersIgnoringModifiers: "A")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.control + KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "A")
     }
 
     func test_KCKeystroke_displaysOptLetterByDefault() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "U")
     }
 
     // MARK: - Function Row
 
     func test_KCKeystroke_convertsFnF1ToBrightnessDecrease() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), UnicodeToken.brightnessDown.string)
     }
 
     func test_KCKeystroke_convertsFnF2ToBrightnessIncrease() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), UnicodeToken.brightnessUp.string)
     }
 
     func test_KCKeystroke_convertsFnF3ToMissionControl() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), UnicodeToken.missionControl.string)
     }
 
     func test_KCKeystroke_convertsFnF4ToLauncher() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), UnicodeToken.launchpad.string)
     }
 
     // MARK: - JIS layout
 
     func test_KCKeystroke_convertsEisuKey() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.eisu.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.eisu.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "英数")
     }
 
     func test_KCKeystroke_convertsKanaKey() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.kana.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.kana.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "かな")
     }
 
     // MARK: - Option-modified characters
 
     func test_optionShiftNumberDisplaysExplicitModifiers() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "7")
     }
 
     // MARK: - Special Cases
 
     func test_tabKey() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.none, characters: "\t", charactersIgnoringModifiers: "\t")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.none, characters: "\t", charactersIgnoringModifiers: "\t")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.tab)
     }
 
     func test_returnAndKeypadEnterUseDifferentSymbols() {
-        keystroke = makeKeystroke(
+        keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.returnKey.rawValue,
             modifiers: TestModifierFlags.none,
             characters: "\r",
@@ -174,7 +157,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         )
         XCTAssertEqual(transform(keystroke), UnicodeToken.returnKey.string)
 
-        keystroke = makeKeystroke(
+        keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.keypadEnter.rawValue,
             modifiers: TestModifierFlags.none,
             characters: "\r",
@@ -184,7 +167,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     }
 
     func test_deleteAndForwardDeleteUseDifferentSymbols() {
-        keystroke = makeKeystroke(
+        keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.delete.rawValue,
             modifiers: TestModifierFlags.none,
             characters: UnicodeToken.delete.string,
@@ -192,7 +175,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         )
         XCTAssertEqual(transform(keystroke), UnicodeToken.delete.string)
 
-        keystroke = makeKeystroke(
+        keystroke = TestKeystrokes.make(
             keyCode: KeyboardKeyCode.forwardDelete.rawValue,
             modifiers: TestModifierFlags.none,
             characters: UnicodeToken.forwardDelete.string,
@@ -203,7 +186,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_shiftTab() {
         let ch = TestKeyboardCharacters.backTab
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.shift, characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.shift, characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.backTab)
     }
 
@@ -216,7 +199,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         ]
 
         for (keyCode, expected) in cases {
-            keystroke = makeKeystroke(
+            keystroke = TestKeystrokes.make(
                 keyCode: keyCode.rawValue,
                 modifiers: TestModifierFlags.none,
                 characters: expected,
@@ -228,18 +211,18 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_insertFunctionKeyDisplaysInsertForHelpKeyCode() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSInsertFunctionKey)
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), "ins")
     }
 
     func test_helpFunctionKeyDisplaysHelpForHelpKeyCode() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSHelpFunctionKey)
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), UnicodeToken.questionMark.string + UnicodeToken.enclosingCircle.string)
     }
 
     func test_helpKeyCodeWithoutSemanticCharactersDefaultsToInsert() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "ins")
     }
 
@@ -247,7 +230,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_optionShiftUp() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSUpArrowFunctionKey)
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
 
         XCTAssertEqual(
             transform(keystroke),
@@ -256,24 +239,24 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     }
 
     func test_optionUSpecialCase() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "U")
     }
 
     func test_optionESpecialCase() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.e.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "e")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.e.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "e")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "E")
     }
 
     func test_optionBacktickSpecialCase() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "`")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "`")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.option + "`")
     }
 
     // MARK: - German - Special Case
 
     func test_commandßDisplaysCommandß() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: TestModifierFlags.command, characters: "ß", charactersIgnoringModifiers: "ß")
+        keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: TestModifierFlags.command, characters: "ß", charactersIgnoringModifiers: "ß")
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.command + "ß")
     }
 

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -202,7 +202,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     }
 
     func test_shiftTab() {
-        let ch = String(UnicodeScalar(0x19)!)
+        let ch = TestKeyboardCharacters.backTab
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.shift, characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.backTab)
     }
@@ -227,13 +227,13 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     }
 
     func test_insertFunctionKeyDisplaysInsertForHelpKeyCode() {
-        let ch = Self.appKitFunctionKey(NSInsertFunctionKey)
+        let ch = TestKeyboardCharacters.functionKeyCharacter(NSInsertFunctionKey)
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), "ins")
     }
 
     func test_helpFunctionKeyDisplaysHelpForHelpKeyCode() {
-        let ch = Self.appKitFunctionKey(NSHelpFunctionKey)
+        let ch = TestKeyboardCharacters.functionKeyCharacter(NSHelpFunctionKey)
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), UnicodeToken.questionMark.string + UnicodeToken.enclosingCircle.string)
     }
@@ -246,7 +246,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     // MARK: - US English - Special Cases with Modifiers
 
     func test_optionShiftUp() {
-        let ch = Self.appKitFunctionKey(NSUpArrowFunctionKey)
+        let ch = TestKeyboardCharacters.functionKeyCharacter(NSUpArrowFunctionKey)
         keystroke = makeKeystroke(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
 
         XCTAssertEqual(
@@ -277,7 +277,4 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         XCTAssertEqual(transform(keystroke), KeyboardGlyphCatalog.command + "ß")
     }
 
-    private static func appKitFunctionKey(_ key: Int) -> String {
-        String(UnicodeScalar(key)!)
-    }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -46,96 +46,96 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     // MARK: - Numbers
 
     func test_KCKeystroke_convertsCtrlNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 262401), characters: "7", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.control, characters: "7", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌃7")
     }
 
     func test_KCKeystroke_convertsShiftNumberToShiftNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 131330), characters: "&", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.shift, characters: "&", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⇧7")
     }
 
     func test_KCKeystroke_convertsCtrlShiftNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 393475), characters: "7", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.controlShift, characters: "7", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⌃⇧7")
     }
 
     func test_KCKeystroke_convertsCmdNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1048840), characters: "7", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.command, characters: "7", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌘7")
     }
 
     func test_KCKeystroke_convertsCmdShiftNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1179914), characters: "7", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandShift, characters: "7", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⇧⌘7")
     }
 
     func test_KCKeystroke_convertsCmdOptNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1573160), characters: "¶", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOption, characters: "¶", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌥⌘7")
     }
 
     func test_KCKeystroke_convertsShiftOptionNumberToNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 655650), characters: "»", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌥⇧7")
     }
 
     func test_KCKeystroke_convertsCmdOptShiftNumberToShiftedNumber() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1704234), characters: "‡", charactersIgnoringModifiers: "&")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.commandOptionShift, characters: "‡", charactersIgnoringModifiers: "&")
         XCTAssertEqual(transform(keystroke), "⌥⇧⌘7")
     }
 
     // MARK: - Letters
 
     func test_KCKeystroke_convertsCtrlLetterToUppercaseLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 262401), characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.control, characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), "⌃A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 393475), characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlShift, characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), "⌃⇧A")
     }
 
     func test_KCKeystroke_convertsCtrlShiftCmdLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1442059), characters: "^A", charactersIgnoringModifiers: "A")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlCommandShift, characters: "^A", charactersIgnoringModifiers: "A")
         XCTAssertEqual(transform(keystroke), "⌃⇧⌘A")
     }
 
     func test_KCKeystroke_convertsCtrlOptLetterToUppercaseLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 786721), characters: "^A", charactersIgnoringModifiers: "a")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOption, characters: "^A", charactersIgnoringModifiers: "a")
         XCTAssertEqual(transform(keystroke), "⌃⌥A")
     }
 
     func test_KCKeystroke_convertsCtrlOptShiftLetterToLetter() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 917795), characters: "^A", charactersIgnoringModifiers: "A")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.a.rawValue, modifiers: TestModifierFlags.controlOptionShift, characters: "^A", charactersIgnoringModifiers: "A")
         XCTAssertEqual(transform(keystroke), "⌃⌥⇧A")
     }
 
     func test_KCKeystroke_displaysOptLetterByDefault() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "u")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
         XCTAssertEqual(transform(keystroke), "⌥U")
     }
 
     // MARK: - Function Row
 
     func test_KCKeystroke_convertsFnF1ToBrightnessDecrease() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🔅")
     }
 
     func test_KCKeystroke_convertsFnF2ToBrightnessIncrease() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🔆")
     }
 
     func test_KCKeystroke_convertsFnF3ToMissionControl() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🖥")
     }
 
     func test_KCKeystroke_convertsFnF4ToLauncher() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 8388864), characters: "", charactersIgnoringModifiers: "")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
         XCTAssertEqual(transform(keystroke), "🚀")
     }
 
@@ -154,21 +154,21 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     // MARK: - Option-modified characters
 
     func test_optionShiftNumberDisplaysExplicitModifiers() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 655650), characters: "»", charactersIgnoringModifiers: "7")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.digit7.rawValue, modifiers: TestModifierFlags.optionShift, characters: "»", charactersIgnoringModifiers: "7")
         XCTAssertEqual(transform(keystroke), "⌥⇧7")
     }
 
     // MARK: - Special Cases
 
     func test_tabKey() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 256), characters: "\t", charactersIgnoringModifiers: "\t")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.none, characters: "\t", charactersIgnoringModifiers: "\t")
         XCTAssertEqual(transform(keystroke), "⇥")
     }
 
     func test_returnAndKeypadEnterUseDifferentSymbols() {
         keystroke = makeKeystroke(
             keyCode: KeyboardKeyCode.returnKey.rawValue,
-            modifiers: NSEvent.ModifierFlags(rawValue: 256),
+            modifiers: TestModifierFlags.none,
             characters: "\r",
             charactersIgnoringModifiers: "\r"
         )
@@ -176,7 +176,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
         keystroke = makeKeystroke(
             keyCode: KeyboardKeyCode.keypadEnter.rawValue,
-            modifiers: NSEvent.ModifierFlags(rawValue: 256),
+            modifiers: TestModifierFlags.none,
             characters: "\r",
             charactersIgnoringModifiers: "\r"
         )
@@ -186,7 +186,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
     func test_deleteAndForwardDeleteUseDifferentSymbols() {
         keystroke = makeKeystroke(
             keyCode: KeyboardKeyCode.delete.rawValue,
-            modifiers: NSEvent.ModifierFlags(rawValue: 256),
+            modifiers: TestModifierFlags.none,
             characters: UnicodeToken.delete.string,
             charactersIgnoringModifiers: UnicodeToken.delete.string
         )
@@ -194,7 +194,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
         keystroke = makeKeystroke(
             keyCode: KeyboardKeyCode.forwardDelete.rawValue,
-            modifiers: NSEvent.ModifierFlags(rawValue: 256),
+            modifiers: TestModifierFlags.none,
             characters: UnicodeToken.forwardDelete.string,
             charactersIgnoringModifiers: UnicodeToken.forwardDelete.string
         )
@@ -203,7 +203,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_shiftTab() {
         let ch = String(UnicodeScalar(0x19)!)
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 131330), characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.tab.rawValue, modifiers: TestModifierFlags.shift, characters: ch, charactersIgnoringModifiers: ch)
         XCTAssertEqual(transform(keystroke), "⇤")
     }
 
@@ -218,7 +218,7 @@ final class EventTransformerKeystrokeTests: XCTestCase {
         for (keyCode, expected) in cases {
             keystroke = makeKeystroke(
                 keyCode: keyCode.rawValue,
-                modifiers: NSEvent.ModifierFlags(rawValue: 256),
+                modifiers: TestModifierFlags.none,
                 characters: expected,
                 charactersIgnoringModifiers: expected
             )
@@ -247,30 +247,30 @@ final class EventTransformerKeystrokeTests: XCTestCase {
 
     func test_optionShiftUp() {
         let ch = String(format: "%lu", UInt64(0x00006000002f5c00))
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 11141410), characters: ch, charactersIgnoringModifiers: ch)
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.upArrow.rawValue, modifiers: TestModifierFlags.functionOptionShiftNumericPad, characters: ch, charactersIgnoringModifiers: ch)
 
         XCTAssertEqual(transform(keystroke), "⌥⇧▲")
     }
 
     func test_optionUSpecialCase() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "u")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.u.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "u")
         XCTAssertEqual(transform(keystroke), "⌥U")
     }
 
     func test_optionESpecialCase() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.e.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "e")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.e.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "e")
         XCTAssertEqual(transform(keystroke), "⌥E")
     }
 
     func test_optionBacktickSpecialCase() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 524576), characters: "", charactersIgnoringModifiers: "`")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.grave.rawValue, modifiers: TestModifierFlags.option, characters: "", charactersIgnoringModifiers: "`")
         XCTAssertEqual(transform(keystroke), "⌥`")
     }
 
     // MARK: - German - Special Case
 
     func test_commandßDisplaysCommandß() {
-        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: NSEvent.ModifierFlags(rawValue: 1048840), characters: "ß", charactersIgnoringModifiers: "ß")
+        keystroke = makeKeystroke(keyCode: KeyboardKeyCode.minus.rawValue, modifiers: TestModifierFlags.command, characters: "ß", charactersIgnoringModifiers: "ß")
         XCTAssertEqual(transform(keystroke), "⌘ß")
     }
 

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerMouseTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerMouseTests.swift
@@ -17,66 +17,45 @@ final class EventTransformerMouseTests: XCTestCase {
         EventTransformer(keyboardLayout: keyboardLayout).transform(.mouse(event))
     }
 
-    func makeMouseEvent(type: NSEvent.EventType, buttonNumber: Int,
-                        modifiers: NSEvent.ModifierFlags) -> MouseEvent {
-        let cgType: CGEventType = {
-            switch type {
-            case .leftMouseDown: return .leftMouseDown
-            case .rightMouseDown: return .rightMouseDown
-            default: return .otherMouseDown
-            }
-        }()
-        var cgFlags: CGEventFlags = []
-        if modifiers.contains(.shift)   { cgFlags.insert(.maskShift) }
-        if modifiers.contains(.command) { cgFlags.insert(.maskCommand) }
-        if modifiers.contains(.control) { cgFlags.insert(.maskControl) }
-        if modifiers.contains(.option)  { cgFlags.insert(.maskAlternate) }
-        let cgEvent = CGEvent(mouseEventSource: nil, mouseType: cgType,
-                              mouseCursorPosition: .zero, mouseButton: .left)!
-        cgEvent.setIntegerValueField(.mouseEventButtonNumber, value: Int64(buttonNumber))
-        cgEvent.flags = cgFlags
-        return MouseEvent(nsEvent: NSEvent(cgEvent: cgEvent)!)
-    }
-
     override func setUpWithError() throws {
         try super.setUpWithError()
-        keyboardLayout = try TestKeyboardLayouts.requireUSEnglish()
+        self.keyboardLayout = try TestKeyboardLayouts.requireUSEnglish()
     }
 
     // MARK: - Mouse buttons
 
     func test_MouseEvent_leftMouseDownIsLMB() {
-        let event = makeMouseEvent(type: .leftMouseDown, buttonNumber: 0, modifiers: [])
+        let event = TestMouseEvents.make(type: .leftMouseDown, buttonNumber: 0, modifiers: [])
         XCTAssertEqual(transform(event), "LMB")
     }
 
     func test_MouseEvent_rightMouseDownIsRMB() {
-        let event = makeMouseEvent(type: .rightMouseDown, buttonNumber: 1, modifiers: [])
+        let event = TestMouseEvents.make(type: .rightMouseDown, buttonNumber: 1, modifiers: [])
         XCTAssertEqual(transform(event), "RMB")
     }
 
     func test_MouseEvent_middleMouseDownIsMMB() {
-        let event = makeMouseEvent(type: .otherMouseDown, buttonNumber: 2, modifiers: [])
+        let event = TestMouseEvents.make(type: .otherMouseDown, buttonNumber: 2, modifiers: [])
         XCTAssertEqual(transform(event), "MMB")
     }
 
     func test_MouseEvent_fourthButtonIsMB4() {
-        let event = makeMouseEvent(type: .otherMouseDown, buttonNumber: 3, modifiers: [])
+        let event = TestMouseEvents.make(type: .otherMouseDown, buttonNumber: 3, modifiers: [])
         XCTAssertEqual(transform(event), "MB4")
     }
 
     func test_MouseEvent_fifthButtonIsMB5() {
-        let event = makeMouseEvent(type: .otherMouseDown, buttonNumber: 4, modifiers: [])
+        let event = TestMouseEvents.make(type: .otherMouseDown, buttonNumber: 4, modifiers: [])
         XCTAssertEqual(transform(event), "MB5")
     }
 
     func test_MouseEvent_commandLeftClickShowsCommandLMB() {
-        let event = makeMouseEvent(type: .leftMouseDown, buttonNumber: 0, modifiers: .command)
+        let event = TestMouseEvents.make(type: .leftMouseDown, buttonNumber: 0, modifiers: .command)
         XCTAssertEqual(transform(event), "⌘LMB")
     }
 
     func test_MouseEvent_optionShiftRightClickShowsModifiersWithRMB() {
-        let event = makeMouseEvent(type: .rightMouseDown, buttonNumber: 1, modifiers: [.option, .shift])
+        let event = TestMouseEvents.make(type: .rightMouseDown, buttonNumber: 1, modifiers: [.option, .shift])
         XCTAssertEqual(transform(event), "⌥⇧RMB")
     }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerMouseTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerMouseTests.swift
@@ -12,21 +12,9 @@ import XCTest
 
 final class EventTransformerMouseTests: XCTestCase {
     var keyboardLayout: TISInputSource!
-    var keyboardLayouts: [TISInputSource] = []
 
     func transform(_ event: MouseEvent) -> String {
         EventTransformer(keyboardLayout: keyboardLayout).transform(.mouse(event))
-    }
-
-    func usEnglishKeyboardLayout() -> TISInputSource {
-        let properties: [String: Any] = [
-            kTISPropertyInputSourceID as String: "com.apple.keylayout.US",
-            kTISPropertyInputSourceType as String: kTISTypeKeyboardLayout as String
-        ]
-        keyboardLayouts = TISCreateInputSourceList(properties as CFDictionary, true)!
-            .takeRetainedValue() as! [TISInputSource]
-        XCTAssertGreaterThan(keyboardLayouts.count, 0)
-        return keyboardLayouts[0]
     }
 
     func makeMouseEvent(type: NSEvent.EventType, buttonNumber: Int,
@@ -50,9 +38,9 @@ final class EventTransformerMouseTests: XCTestCase {
         return MouseEvent(nsEvent: NSEvent(cgEvent: cgEvent)!)
     }
 
-    override func setUp() {
-        super.setUp()
-        keyboardLayout = usEnglishKeyboardLayout()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        keyboardLayout = try TestKeyboardLayouts.requireUSEnglish()
     }
 
     // MARK: - Mouse buttons

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerMouseTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerMouseTests.swift
@@ -51,11 +51,11 @@ final class EventTransformerMouseTests: XCTestCase {
 
     func test_MouseEvent_commandLeftClickShowsCommandLMB() {
         let event = TestMouseEvents.make(type: .leftMouseDown, buttonNumber: 0, modifiers: .command)
-        XCTAssertEqual(transform(event), "⌘LMB")
+        XCTAssertEqual(transform(event), KeyboardGlyphCatalog.command + "LMB")
     }
 
     func test_MouseEvent_optionShiftRightClickShowsModifiersWithRMB() {
         let event = TestMouseEvents.make(type: .rightMouseDown, buttonNumber: 1, modifiers: [.option, .shift])
-        XCTAssertEqual(transform(event), "⌥⇧RMB")
+        XCTAssertEqual(transform(event), KeyboardGlyphCatalog.option + KeyboardGlyphCatalog.shift + "RMB")
     }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Support/TestKeyboardCharacters.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Support/TestKeyboardCharacters.swift
@@ -1,0 +1,17 @@
+//
+//  TestKeyboardCharacters.swift
+//  KeytyTests
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import AppKit
+
+enum TestKeyboardCharacters {
+    static func functionKeyCharacter(_ key: Int) -> String {
+        String(UnicodeScalar(key)!)
+    }
+
+    static let backTab = String(UnicodeScalar(NSBackTabCharacter)!)
+}

--- a/Apps/Keyty/Tests/KeytyTests/Support/TestKeyboardLayouts.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Support/TestKeyboardLayouts.swift
@@ -1,0 +1,33 @@
+//
+//  TestKeyboardLayouts.swift
+//  KeytyTests
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Carbon
+import XCTest
+
+enum TestKeyboardLayouts {
+    static func requireUSEnglish(file: StaticString = #filePath,
+                                 line: UInt = #line) throws -> TISInputSource {
+        let properties: [String: Any] = [
+            kTISPropertyInputSourceID as String: "com.apple.keylayout.US",
+            kTISPropertyInputSourceType as String: kTISTypeKeyboardLayout as String
+        ]
+        let inputSources = try XCTUnwrap(
+            TISCreateInputSourceList(properties as CFDictionary, true)?
+                .takeRetainedValue() as? [TISInputSource],
+            "Expected the US English keyboard layout to be available",
+            file: file,
+            line: line
+        )
+        return try XCTUnwrap(
+            inputSources.first,
+            "Expected the US English keyboard layout to be available",
+            file: file,
+            line: line
+        )
+    }
+}

--- a/Apps/Keyty/Tests/KeytyTests/Support/TestKeystrokes.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Support/TestKeystrokes.swift
@@ -1,0 +1,33 @@
+//
+//  TestKeystrokes.swift
+//  KeytyTests
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import AppKit
+@testable import Keyty
+
+enum TestKeystrokes {
+    static func make(
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags = [],
+        characters: String,
+        charactersIgnoringModifiers: String
+    ) -> StandardKeyEvent {
+        let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: NSDate.timeIntervalSinceReferenceDate,
+            windowNumber: 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: charactersIgnoringModifiers,
+            isARepeat: false,
+            keyCode: keyCode
+        )!
+        return StandardKeyEvent(nsEvent: event)
+    }
+}

--- a/Apps/Keyty/Tests/KeytyTests/Support/TestModifierFlags.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Support/TestModifierFlags.swift
@@ -1,0 +1,63 @@
+//
+//  TestModifierFlags.swift
+//  KeytyTests
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import AppKit
+import IOKit.hidsystem
+@testable import Keyty
+
+enum TestModifierFlags {
+    private static let recordedEventStateMask: UInt = 0x100
+
+    static let none = Self.recorded([])
+    static let control = Self.recorded(.control, deviceMasks: UInt(NX_DEVICELCTLKEYMASK))
+    static let shift = Self.recorded(.shift, deviceMasks: UInt(NX_DEVICELSHIFTKEYMASK))
+    static let controlShift = Self.recorded(
+        [.control, .shift],
+        deviceMasks: UInt(NX_DEVICELCTLKEYMASK), UInt(NX_DEVICELSHIFTKEYMASK)
+    )
+    static let command = Self.recorded(.command, deviceMasks: UInt(NX_DEVICELCMDKEYMASK))
+    static let commandShift = Self.recorded(
+        [.command, .shift],
+        deviceMasks: UInt(NX_DEVICELCMDKEYMASK), UInt(NX_DEVICELSHIFTKEYMASK)
+    )
+    static let commandOption = Self.recorded(
+        [.command, .option],
+        deviceMasks: UInt(NX_DEVICELCMDKEYMASK), UInt(NX_DEVICELALTKEYMASK)
+    )
+    static let commandOptionShift = Self.recorded(
+        [.command, .option, .shift],
+        deviceMasks: UInt(NX_DEVICELCMDKEYMASK), UInt(NX_DEVICELALTKEYMASK), UInt(NX_DEVICELSHIFTKEYMASK)
+    )
+    static let controlCommandShift = Self.recorded(
+        [.control, .command, .shift],
+        deviceMasks: UInt(NX_DEVICELCTLKEYMASK), UInt(NX_DEVICELCMDKEYMASK), UInt(NX_DEVICELSHIFTKEYMASK)
+    )
+    static let controlOption = Self.recorded(
+        [.control, .option],
+        deviceMasks: UInt(NX_DEVICELCTLKEYMASK), UInt(NX_DEVICELALTKEYMASK)
+    )
+    static let controlOptionShift = Self.recorded(
+        [.control, .option, .shift],
+        deviceMasks: UInt(NX_DEVICELCTLKEYMASK), UInt(NX_DEVICELALTKEYMASK), UInt(NX_DEVICELSHIFTKEYMASK)
+    )
+    static let option = Self.recorded(.option, deviceMasks: UInt(NX_DEVICELALTKEYMASK))
+    static let optionShift = Self.recorded(
+        [.option, .shift],
+        deviceMasks: UInt(NX_DEVICELALTKEYMASK), UInt(NX_DEVICELSHIFTKEYMASK)
+    )
+    static let function = Self.recorded(.function)
+    static let functionOptionShiftNumericPad = Self.recorded(
+        [.function, .option, .shift, .numericPad],
+        deviceMasks: UInt(NX_DEVICELALTKEYMASK), UInt(NX_DEVICELSHIFTKEYMASK)
+    )
+
+    private static func recorded(_ flags: NSEvent.ModifierFlags,
+                                 deviceMasks: UInt...) -> NSEvent.ModifierFlags {
+        flags.addingRawMasks([recordedEventStateMask] + deviceMasks)
+    }
+}

--- a/Apps/Keyty/Tests/KeytyTests/Support/TestMouseEvents.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Support/TestMouseEvents.swift
@@ -1,0 +1,57 @@
+//
+//  TestMouseEvents.swift
+//  KeytyTests
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import AppKit
+@testable import Keyty
+
+enum TestMouseEvents {
+    static func make(
+        type: NSEvent.EventType,
+        buttonNumber: Int = 0,
+        modifiers: NSEvent.ModifierFlags = []
+    ) -> MouseEvent {
+        let cgEvent = CGEvent(
+            mouseEventSource: nil,
+            mouseType: Self.cgMouseEventType(for: type),
+            mouseCursorPosition: .zero,
+            mouseButton: Self.cgMouseButton(for: type)
+        )!
+        cgEvent.setIntegerValueField(.mouseEventButtonNumber, value: Int64(buttonNumber))
+        cgEvent.flags = Self.cgEventFlags(for: modifiers)
+        return MouseEvent(nsEvent: NSEvent(cgEvent: cgEvent)!)
+    }
+
+    private static func cgMouseEventType(for nsEventType: NSEvent.EventType) -> CGEventType {
+        switch nsEventType {
+        case .leftMouseDown: return .leftMouseDown
+        case .leftMouseUp: return .leftMouseUp
+        case .rightMouseDown: return .rightMouseDown
+        case .rightMouseUp: return .rightMouseUp
+        case .otherMouseDown: return .otherMouseDown
+        case .otherMouseUp: return .otherMouseUp
+        default: return .otherMouseDown
+        }
+    }
+
+    private static func cgMouseButton(for nsEventType: NSEvent.EventType) -> CGMouseButton {
+        switch nsEventType {
+        case .rightMouseDown, .rightMouseUp: return .right
+        default: return .left
+        }
+    }
+
+    private static func cgEventFlags(for modifierFlags: NSEvent.ModifierFlags) -> CGEventFlags {
+        var flags: CGEventFlags = []
+        if modifierFlags.contains(.shift) { flags.insert(.maskShift) }
+        if modifierFlags.contains(.command) { flags.insert(.maskCommand) }
+        if modifierFlags.contains(.control) { flags.insert(.maskControl) }
+        if modifierFlags.contains(.option) { flags.insert(.maskAlternate) }
+        if modifierFlags.contains(.function) { flags.insert(.maskSecondaryFn) }
+        return flags
+    }
+}


### PR DESCRIPTION
## Summary

Centralizes event transformer test fixtures and replaces raw test values with shared domain helpers. This keeps keyboard key codes, modifier flags, AppKit keyboard characters, mouse events, and keystrokes named in one place while preserving existing transformer behavior.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/EventTransformerKeystrokeTests`
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/EventTransformerKeystrokeTests -only-testing:KeytyTests/KeyboardVisualizerSpecialKeyFilteringTests`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A
