### PR TITLE
docs(agents): document merged PR labeling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@ Run `tuist generate` after changing `Project.swift`, dependencies, build setting
 - Branch names should follow `<type>/<short-description>`, for example `fix/menu-bar-position` or `feat/input-overlay-theme`.
 - Commit messages should follow `<type>(<scope>): <description>` when a scope is useful, for example `fix(settings): clamp overlay opacity`.
 - When creating a pull request, always use the existing GitHub pull request template.
+- Keep merged pull requests labeled according to their content. Generated release
+  notes use `.github/release.yml`: `enhancement` appears under New features,
+  `bug` under Bug fixes, `ignore for release` is excluded, and other labels fall
+  through to Other changes.
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

Document that merged pull requests should stay labeled according to their content because labels drive generated release notes.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Not run; documentation-only change.

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
