### PR TITLE
fix(keyboard): track media key press state

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane+PreviewGroup.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane+PreviewGroup.swift
@@ -167,10 +167,10 @@ extension KeyboardSettingsPane.PreviewGroup {
     private static func mediaKeySampleGroups() -> [[KeycapPreviewSample]] {
         [
             [
-                .media(.brightnessUp)
+                .media(.brightnessUp, isPressed: true)
             ],
             [
-                .media(.play)
+                .media(.play, isPressed: true)
             ],
         ]
     }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
@@ -96,7 +96,9 @@ final class KeyboardVisualizer {
             self.prepareForNextContentEvent()
 
             let keycap = KeycapItemFactory.mediaKeyItem(for: mediaKey, palette: self.visualizerSettings.palette)
-            self.eventCoordinator.handleStandalone(
+            self.eventCoordinator.handleMediaKey(
+                kind: mediaKey.kind,
+                isPressed: keycap.isPressed,
                 items: [keycap],
                 appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
                 updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeycapEventCoordinator.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeycapEventCoordinator.swift
@@ -13,17 +13,22 @@ protocol KeycapGroupItem {
 }
 
 final class KeycapEventCoordinator<GroupView: AnyObject, Item: KeycapGroupItem> {
+    private enum TrackedButtonIdentifier: Hashable {
+        case mouse(MouseEvent.Kind)
+        case media(MediaKeyEvent.Kind)
+    }
+
     private var pendingModifierGroup: GroupView?
     private var completedModifierGroup: GroupView?
     private var activeKeyGroups: [UInt16: GroupView] = [:]
-    private var activeMouseGroups: [MouseEvent.Kind: GroupView] = [:]
+    private var activeButtonGroups: [TrackedButtonIdentifier: GroupView] = [:]
     private var groupItems: [ObjectIdentifier: [Item]] = [:]
 
     func reset() {
         self.pendingModifierGroup = nil
         self.completedModifierGroup = nil
         self.activeKeyGroups.removeAll(keepingCapacity: true)
-        self.activeMouseGroups.removeAll(keepingCapacity: true)
+        self.activeButtonGroups.removeAll(keepingCapacity: true)
         self.groupItems.removeAll(keepingCapacity: true)
     }
 
@@ -35,7 +40,7 @@ final class KeycapEventCoordinator<GroupView: AnyObject, Item: KeycapGroupItem> 
             self.completedModifierGroup = nil
         }
         self.activeKeyGroups = self.activeKeyGroups.filter { $0.value !== group }
-        self.activeMouseGroups = self.activeMouseGroups.filter { $0.value !== group }
+        self.activeButtonGroups = self.activeButtonGroups.filter { $0.value !== group }
         self.groupItems[ObjectIdentifier(group)] = nil
     }
 
@@ -131,38 +136,13 @@ final class KeycapEventCoordinator<GroupView: AnyObject, Item: KeycapGroupItem> 
         appendGroup: ([Item]) -> GroupView,
         updateGroup: (GroupView, [Item]) -> Void
     ) {
-        guard !items.isEmpty else { return }
-
-        if let activeGroup = self.activeMouseGroups[kind] {
-            let merged = self.ordered(items: self.merged(items: items, into: self.storedItems(for: activeGroup)))
-            self.groupItems[ObjectIdentifier(activeGroup)] = merged
-            updateGroup(activeGroup, merged)
-            self.pendingModifierGroup = activeGroup
-            self.completedModifierGroup = activeGroup
-            if !isPressed {
-                self.activeMouseGroups[kind] = nil
-            }
-            return
-        }
-
-        if let pendingModifierGroup, self.canAbsorbIntoPendingChord(pendingModifierGroup) {
-            let merged = self.ordered(items: self.merged(items: items, into: self.storedItems(for: pendingModifierGroup)))
-            self.groupItems[ObjectIdentifier(pendingModifierGroup)] = merged
-            updateGroup(pendingModifierGroup, merged)
-            self.completedModifierGroup = pendingModifierGroup
-            if isPressed {
-                self.activeMouseGroups[kind] = pendingModifierGroup
-            }
-            return
-        }
-
-        let orderedItems = self.ordered(items: items)
-        let group = appendGroup(orderedItems)
-        self.groupItems[ObjectIdentifier(group)] = orderedItems
-        self.completedModifierGroup = group
-        if isPressed {
-            self.activeMouseGroups[kind] = group
-        }
+        self.handleTrackedButton(
+            identifier: .mouse(kind),
+            isPressed: isPressed,
+            items: items,
+            appendGroup: appendGroup,
+            updateGroup: updateGroup
+        )
     }
 
     func handleStandalone(
@@ -183,12 +163,69 @@ final class KeycapEventCoordinator<GroupView: AnyObject, Item: KeycapGroupItem> 
         let group = appendGroup(items)
         self.groupItems[ObjectIdentifier(group)] = items
     }
+
+    func handleMediaKey(
+        kind: MediaKeyEvent.Kind,
+        isPressed: Bool,
+        items: [Item],
+        appendGroup: ([Item]) -> GroupView,
+        updateGroup: (GroupView, [Item]) -> Void
+    ) {
+        self.handleTrackedButton(
+            identifier: .media(kind),
+            isPressed: isPressed,
+            items: items,
+            appendGroup: appendGroup,
+            updateGroup: updateGroup
+        )
+    }
 }
 
 // MARK: - Private API
 private extension KeycapEventCoordinator {
     private func storedItems(for group: GroupView) -> [Item] {
         self.groupItems[ObjectIdentifier(group)] ?? []
+    }
+
+    private func handleTrackedButton(
+        identifier: TrackedButtonIdentifier,
+        isPressed: Bool,
+        items: [Item],
+        appendGroup: ([Item]) -> GroupView,
+        updateGroup: (GroupView, [Item]) -> Void
+    ) {
+        guard !items.isEmpty else { return }
+
+        if let activeGroup = self.activeButtonGroups[identifier] {
+            let merged = self.ordered(items: self.merged(items: items, into: self.storedItems(for: activeGroup)))
+            self.groupItems[ObjectIdentifier(activeGroup)] = merged
+            updateGroup(activeGroup, merged)
+            self.pendingModifierGroup = activeGroup
+            self.completedModifierGroup = activeGroup
+            if !isPressed {
+                self.activeButtonGroups[identifier] = nil
+            }
+            return
+        }
+
+        if let pendingModifierGroup, self.canAbsorbIntoPendingChord(pendingModifierGroup) {
+            let merged = self.ordered(items: self.merged(items: items, into: self.storedItems(for: pendingModifierGroup)))
+            self.groupItems[ObjectIdentifier(pendingModifierGroup)] = merged
+            updateGroup(pendingModifierGroup, merged)
+            self.completedModifierGroup = pendingModifierGroup
+            if isPressed {
+                self.activeButtonGroups[identifier] = pendingModifierGroup
+            }
+            return
+        }
+
+        let orderedItems = self.ordered(items: items)
+        let group = appendGroup(orderedItems)
+        self.groupItems[ObjectIdentifier(group)] = orderedItems
+        self.completedModifierGroup = group
+        if isPressed {
+            self.activeButtonGroups[identifier] = group
+        }
     }
 
     /// Only pure modifier previews can absorb later modifier-only updates.

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeycapItemFactory.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeycapItemFactory.swift
@@ -128,7 +128,7 @@ enum KeycapItemFactory {
     }
 
     static func mediaKeyItem(for mediaKey: MediaKeyEvent, palette: KeycapThemePalette) -> KeycapItem {
-        Self.mediaKeyItem(for: mediaKey.kind, isPressed: false, palette: palette)
+        Self.mediaKeyItem(for: mediaKey.kind, isPressed: mediaKey.isPressed, palette: palette)
     }
 
     static func mediaKeyItem(

--- a/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
+++ b/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
@@ -193,7 +193,7 @@ extension CaptureController: EventTapDelegate {
     }
 
     func eventTap(_ tap: EventTap, noteMediaKey mediaKey: MediaKeyEvent) {
-        guard self.isCapturing, mediaKey.isPressed, mediaKey.isRecognized else { return }
+        guard self.isCapturing, mediaKey.isRecognized else { return }
         self.eventProcessor.noteMediaKey(mediaKey)
     }
 

--- a/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
@@ -90,6 +90,16 @@ final class KeyboardSettingsPreviewTests: XCTestCase {
         ])
     }
 
+    func testMediaPreviewGroupsRenderPressedMediaKeys() {
+        let groups = KeyboardSettingsPane.PreviewGroup.previewGroups(settings: settings)
+        let mediaGroups = groups.filter { $0.category == .mediaKey }
+
+        XCTAssertEqual(mediaGroups.count, 2)
+        XCTAssertTrue(mediaGroups.allSatisfy { group in
+            group.items.allSatisfy(\.isPressed)
+        })
+    }
+
     func testPreviewGroupsFallBackToKeyboardCategoryOnly() {
         settings.onlyShowModifiedKeystrokes = true
         settings.showSpecialKeys = false

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapEventCoordinatorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapEventCoordinatorTests.swift
@@ -419,6 +419,106 @@ final class KeycapEventCoordinatorTests: XCTestCase {
         XCTAssertEqual(updatedGroups[1].first(where: { $0.identity == .mouse(.leftButton) })?.isPressed, false)
     }
 
+    func testMediaKeyReleaseUpdatesExistingGroup() {
+        let coordinator = KeycapEventCoordinator<TestGroupView, TestItem>()
+        var appendedGroups: [[TestItem]] = []
+        var updatedGroups: [[TestItem]] = []
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: true,
+            items: [TestItem(identity: .media(.play), isPressed: true)],
+            appendGroup: {
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: false,
+            items: [TestItem(identity: .media(.play), isPressed: false)],
+            appendGroup: {
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        XCTAssertEqual(appendedGroups.count, 1)
+        XCTAssertEqual(appendedGroups[0].map(\.identity), [.media(.play)])
+        XCTAssertEqual(appendedGroups[0].first?.isPressed, true)
+        XCTAssertEqual(updatedGroups.count, 1)
+        XCTAssertEqual(updatedGroups[0].map(\.identity), [.media(.play)])
+        XCTAssertEqual(updatedGroups[0].first?.isPressed, false)
+    }
+
+    func testMediaKeyReleaseUpdatesExistingChordGroup() {
+        let coordinator = KeycapEventCoordinator<TestGroupView, TestItem>()
+        var appendedGroups: [[TestItem]] = []
+        var updatedGroups: [[TestItem]] = []
+
+        coordinator.handleFlagsChanged(
+            currentTrackedFlags: [.command],
+            releasedTrackedFlags: [],
+            buildItems: { currentFlags, releasedFlags in
+                Self.modifierItems(currentFlags: currentFlags, releasedFlags: releasedFlags)
+            },
+            appendGroup: {
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: true,
+            items: [
+                TestItem(identity: .modifier(.leftCommand), isPressed: true),
+                TestItem(identity: .media(.play), isPressed: true)
+            ],
+            appendGroup: {
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: false,
+            items: [
+                TestItem(identity: .modifier(.leftCommand), isPressed: true),
+                TestItem(identity: .media(.play), isPressed: false)
+            ],
+            appendGroup: {
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        XCTAssertEqual(appendedGroups.count, 1)
+        XCTAssertEqual(appendedGroups[0].map(\.identity), [.modifier(.leftCommand)])
+        XCTAssertEqual(updatedGroups.count, 2)
+        XCTAssertEqual(updatedGroups[0].map(\.identity), [.modifier(.leftCommand), .media(.play)])
+        XCTAssertEqual(updatedGroups[0].first(where: { $0.identity == .media(.play) })?.isPressed, true)
+        XCTAssertEqual(updatedGroups[1].map(\.identity), [.modifier(.leftCommand), .media(.play)])
+        XCTAssertEqual(updatedGroups[1].first(where: { $0.identity == .media(.play) })?.isPressed, false)
+    }
+
     func testRemoveGroupClearsTrackedKeyState() {
         let coordinator = KeycapEventCoordinator<TestGroupView, TestItem>()
         let removedGroup = TestGroupView()
@@ -497,6 +597,98 @@ final class KeycapEventCoordinatorTests: XCTestCase {
         XCTAssertTrue(updatedGroups.isEmpty)
         XCTAssertEqual(appendedGroups[1].map(\.identity), [.mouse(.leftButton)])
         XCTAssertEqual(appendedGroups[1].first?.isPressed, false)
+    }
+
+    func testRemoveGroupClearsTrackedMediaState() {
+        let coordinator = KeycapEventCoordinator<TestGroupView, TestItem>()
+        let removedGroup = TestGroupView()
+        var appendedGroups: [[TestItem]] = []
+        var updatedGroups: [[TestItem]] = []
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: true,
+            items: [TestItem(identity: .media(.play), isPressed: true)],
+            appendGroup: {
+                appendedGroups.append($0)
+                return removedGroup
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        coordinator.removeGroup(removedGroup)
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: false,
+            items: [TestItem(identity: .media(.play), isPressed: false)],
+            appendGroup: {
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        XCTAssertEqual(appendedGroups.count, 2)
+        XCTAssertTrue(updatedGroups.isEmpty)
+        XCTAssertEqual(appendedGroups[1].map(\.identity), [.media(.play)])
+        XCTAssertEqual(appendedGroups[1].first?.isPressed, false)
+    }
+
+    func testMediaKeyAppendCanRemoveExistingTrackedGroup() {
+        let coordinator = KeycapEventCoordinator<TestGroupView, TestItem>()
+        let removedGroup = TestGroupView()
+        var appendedGroups: [[TestItem]] = []
+        var updatedGroups: [[TestItem]] = []
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: true,
+            items: [TestItem(identity: .media(.play), isPressed: true)],
+            appendGroup: {
+                appendedGroups.append($0)
+                return removedGroup
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        coordinator.handleMediaKey(
+            kind: .next,
+            isPressed: true,
+            items: [TestItem(identity: .media(.next), isPressed: true)],
+            appendGroup: {
+                coordinator.removeGroup(removedGroup)
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        coordinator.handleMediaKey(
+            kind: .play,
+            isPressed: false,
+            items: [TestItem(identity: .media(.play), isPressed: false)],
+            appendGroup: {
+                appendedGroups.append($0)
+                return TestGroupView()
+            },
+            updateGroup: { _, items in
+                updatedGroups.append(items)
+            }
+        )
+
+        XCTAssertEqual(appendedGroups.count, 3)
+        XCTAssertTrue(updatedGroups.isEmpty)
+        XCTAssertEqual(appendedGroups[2].map(\.identity), [.media(.play)])
+        XCTAssertEqual(appendedGroups[2].first?.isPressed, false)
     }
 
     func testRemoveGroupClearsPendingModifierState() {

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeycapItemFactoryTests.swift
@@ -146,6 +146,23 @@ final class KeycapItemFactoryTests: XCTestCase {
         XCTAssertFalse(upItem.isPressed)
     }
 
+    func testMediaKeyItemUsesPressedStateFromMediaKeyEvent() {
+        let palette = Self.makePalette()
+
+        let downItem = KeycapItemFactory.mediaKeyItem(
+            for: Self.makeMediaKeyEvent(keyCode: 16, keyState: 0x0A),
+            palette: palette
+        )
+        let upItem = KeycapItemFactory.mediaKeyItem(
+            for: Self.makeMediaKeyEvent(keyCode: 16, keyState: 0x0B),
+            palette: palette
+        )
+
+        XCTAssertEqual(downItem.identity, .media(.play))
+        XCTAssertTrue(downItem.isPressed)
+        XCTAssertFalse(upItem.isPressed)
+    }
+
     private static func makePalette(
         style: KeycapStyle = .minimal,
         theme: KeyboardVisualizerTheme = .citrus
@@ -162,6 +179,23 @@ final class KeycapItemFactoryTests: XCTestCase {
             groupBackgroundTheme: theme,
             legendColorOverride: nil
         )
+    }
+
+    private static func makeMediaKeyEvent(keyCode: Int, keyState: Int) -> MediaKeyEvent {
+        let data1 = (keyCode << 16) | (keyState << 8)
+        let event = NSEvent.otherEvent(
+            with: .systemDefined,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            subtype: Int16(NX_SUBTYPE_AUX_CONTROL_BUTTONS),
+            data1: data1,
+            data2: 0
+        )!
+
+        return MediaKeyEvent(nsEvent: event)
     }
 
 }


### PR DESCRIPTION
## Summary

Fix media keycaps so they render their pressed state from live media-key events and from settings previews.

Root cause: capture only forwarded media-key down events, and the keycap factory discarded `MediaKeyEvent.isPressed` by hardcoding media keycaps as unpressed. The keyboard visualizer now receives recognized media-key releases and tracks media-key groups so key-up updates the existing rendered group instead of creating a disconnected release.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeycapEventCoordinatorTests -only-testing:KeytyTests/KeycapItemFactoryTests -only-testing:KeytyTests/KeyboardSettingsPreviewTests`

Run project commands from `Apps/Keyty`.

## UI Changes

Media keycaps now show the pressed visual state while held, then update to unpressed on key-up. No screenshots attached.

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Fixed media keycaps so playback, brightness, and volume keys visibly press and release in the keyboard overlay.
