### PR TITLE
style(settings): add borders to preview cards

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane+PreviewCard.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane+PreviewCard.swift
@@ -50,6 +50,11 @@ extension DisplaysSettingsPane {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
                 .frame(height: self.previewHeight)
+                .clipShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                        .stroke(Color.Theme.Border.primary, lineWidth: StrokeWidth.standard)
+                )
             }
         }
     }

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PreviewCard.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Mouse/MouseSettingsPane+PreviewCard.swift
@@ -28,6 +28,11 @@ extension MouseSettingsPane {
                 self.cursorPreview
             }
             .frame(height: Spacing.grid(40))
+            .clipShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
+                    .stroke(Color.Theme.Border.primary, lineWidth: StrokeWidth.standard)
+            )
         }
 
         private var cursorPreview: some View {


### PR DESCRIPTION
## Summary

Adds the same rounded outer border used by the keyboard preview card to the mouse and display preview cards for consistent settings UI treatment.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `git diff --check`, `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug`

Run project commands from `Apps/Keyty`.

## UI Changes

| Before | After |
| --- | --- |
| <img width="905" height="648" alt="Screenshot 2026-08-01 at 18 48 58" src="https://github.com/user-attachments/assets/1cc985bf-57d3-4508-bfbd-cc711059ad61" />  | <img width="905" height="648" alt="Screenshot 2026-08-01 at 18 50 36" src="https://github.com/user-attachments/assets/823b25f6-f9c7-4097-870e-795323dc44c5" /> |
| <img width="905" height="648" alt="Screenshot 2026-08-01 at 18 49 00" src="https://github.com/user-attachments/assets/f28e40d6-13ae-4662-b73d-161e653ca1b1" /> | <img width="905" height="648" alt="Screenshot 2026-08-01 at 18 50 39" src="https://github.com/user-attachments/assets/de35b294-2fc4-4fd1-a64c-29e710c791e7" /> |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A