### PR TITLE
docs(readme): add support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ Keyty requires your permission to receive events from macOS in order to display 
 ## Privacy
 
 Input events are processed locally on your Mac. Keyty does not record, store, or upload your keystrokes, typed text, mouse clicks, or pointer activity. See [PRIVACY.md](Docs/PRIVACY.md) for details, including Sparkle update checks.
+
+## Support
+
+If Keyty is useful to you, consider giving the project a ⭐ on GitHub. It helps more people discover it and is the easiest way to support its development.


### PR DESCRIPTION
## Summary

Add a short support section to the bottom of the README encouraging users who find Keyty useful to star the project on GitHub.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Not needed for this documentation-only change.

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
