### PR TITLE
fix: render keyboard preview keys as unpressed

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane+PreviewGroup.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane+PreviewGroup.swift
@@ -167,10 +167,10 @@ extension KeyboardSettingsPane.PreviewGroup {
     private static func mediaKeySampleGroups() -> [[KeycapPreviewSample]] {
         [
             [
-                .media(.brightnessUp, isPressed: true)
+                .media(.brightnessUp)
             ],
             [
-                .media(.play, isPressed: true)
+                .media(.play)
             ],
         ]
     }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerPlacementWindowController.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerPlacementWindowController.swift
@@ -137,7 +137,7 @@ private extension KeyboardVisualizerPlacementWindowController {
         return KeycapItem(
             identity: identity,
             legend: .character(symbol),
-            state: KeycapState(isPressed: true),
+            state: KeycapState(isPressed: false),
             appearance: settings.palette.appearance(for: identity)
         )
     }

--- a/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
@@ -90,13 +90,13 @@ final class KeyboardSettingsPreviewTests: XCTestCase {
         ])
     }
 
-    func testMediaPreviewGroupsRenderPressedMediaKeys() {
+    func testMediaPreviewGroupsRenderUnpressedMediaKeys() {
         let groups = KeyboardSettingsPane.PreviewGroup.previewGroups(settings: settings)
         let mediaGroups = groups.filter { $0.category == .mediaKey }
 
         XCTAssertEqual(mediaGroups.count, 2)
         XCTAssertTrue(mediaGroups.allSatisfy { group in
-            group.items.allSatisfy(\.isPressed)
+            group.items.allSatisfy { !$0.isPressed }
         })
     }
 


### PR DESCRIPTION
## Summary

Render keyboard preview keycaps in the settings and placement previews as unpressed instead of forcing a pressed state.

This updates the media-key preview samples in keyboard settings and the hardcoded `TEST` placement preview items so preview-only UI better matches the intended idle appearance.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug`

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Fix keyboard preview UI so preview keycaps render in the unpressed state.