### PR TITLE
chore(release): dispatch homebrew tap updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -101,3 +102,66 @@ jobs:
           name: appcast-artifacts
           path: dist/
           if-no-files-found: error
+
+  update-homebrew-tap:
+    if: ${{ !endsWith(github.ref_name, '-test') }}
+    runs-on: ubuntu-latest
+    needs: release
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: appcast-artifacts
+          path: dist
+
+      - name: Resolve release payload
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${GITHUB_REF_NAME#v}"
+          tag="${GITHUB_REF_NAME}"
+          dmg_path="dist/Keyty.dmg"
+
+          if [[ ! -f "$dmg_path" ]]; then
+            echo "missing release artifact: $dmg_path" >&2
+            exit 1
+          fi
+
+          sha256="$(sha256sum "$dmg_path" | awk '{print $1}')"
+          dmg_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/Keyty.dmg"
+
+          {
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "dmg_url=$dmg_url"
+            echo "sha256=$sha256"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch Homebrew tap update
+        if: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh api repos/keytyapp/homebrew-tap/dispatches \
+            --method POST \
+            --input - <<EOF
+          {
+            "event_type": "keyty_release_published",
+            "client_payload": {
+              "version": "${{ steps.release.outputs.version }}",
+              "tag": "${{ steps.release.outputs.tag }}",
+              "dmg_url": "${{ steps.release.outputs.dmg_url }}",
+              "sha256": "${{ steps.release.outputs.sha256 }}"
+            }
+          }
+          EOF
+
+      - name: Skip Homebrew tap update dispatch
+        if: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN == '' }}
+        run: echo "::notice::Skipping Homebrew tap update dispatch because HOMEBREW_TAP_DISPATCH_TOKEN is not configured."

--- a/Docs/RELEASING.md
+++ b/Docs/RELEASING.md
@@ -51,6 +51,7 @@ Configure these repository secrets before running the workflow:
 | `NOTARY_KEY_ID` | App Store Connect API key ID |
 | `NOTARY_ISSUER` | App Store Connect issuer ID |
 | `SPARKLE_ED_KEY_BASE64` | Base64-encoded Sparkle EdDSA private key |
+| `HOMEBREW_TAP_DISPATCH_TOKEN` | Optional token with permission to dispatch workflows in `keytyapp/homebrew-tap`; when present, the release workflow triggers the tap repo's cask-update automation after publishing `v*` release assets |
 
 Optionally configure these repository variables:
 
@@ -65,6 +66,11 @@ The release workflow uploads generated appcast artifacts as an Actions artifact.
 Publish `appcast.xml` from that artifact through the Vercel-hosted site so
 Sparkle reads `https://keyty.app/appcast.xml`. Update archives are hosted as
 GitHub release assets by default.
+
+When `HOMEBREW_TAP_DISPATCH_TOKEN` is configured, the same workflow also
+dispatches `keyty_release_published` to `keytyapp/homebrew-tap` with the new
+release version, tag, DMG URL, and DMG SHA-256 so the tap repo can open its own
+cask update pull request.
 
 Before generating a new appcast, the release lane downloads the currently
 published appcast from `https://keyty.app/appcast.xml` into the Sparkle input


### PR DESCRIPTION
## Summary

Add a post-release workflow job that dispatches the `keytyapp/homebrew-tap` cask update automation after GitHub release artifacts are published, and document the new `HOMEBREW_TAP_DISPATCH_TOKEN` secret in the release guide.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

Release automation can now trigger the Homebrew tap repository to open its own cask update PR after publishing a Keyty release.
