### PR TITLE
fix(menu): localize file menu items

### DIFF
--- a/Apps/Keyty/Sources/Keyty/App/Shell/MainMenu.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Shell/MainMenu.swift
@@ -58,8 +58,8 @@ private extension MenuController {
     }
 
     private func makeFileMenu() -> NSMenu {
-        let menu = NSMenu(title: "File")
-        let close = NSMenuItem(title: "Close Window", action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w")
+        let menu = NSMenu(title: L10n.MainMenu.file)
+        let close = NSMenuItem(title: L10n.MainMenu.closeWindow, action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w")
         close.keyEquivalentModifierMask = [.command]
         menu.addItem(close)
         return menu

--- a/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 /* Main menu */
 "main_menu.about" = "Über %@";
+"main_menu.close_window" = "Fenster schließen";
+"main_menu.file" = "Ablage";
 "main_menu.settings" = "Einstellungen…";
 "main_menu.quit" = "%@ beenden";
 

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 /* Main menu */
 "main_menu.about" = "About %@";
+"main_menu.close_window" = "Close Window";
+"main_menu.file" = "File";
 "main_menu.settings" = "Settings…";
 "main_menu.quit" = "Quit %@";
 

--- a/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 /* Main menu */
 "main_menu.about" = "Acerca de %@";
+"main_menu.close_window" = "Cerrar ventana";
+"main_menu.file" = "Archivo";
 "main_menu.settings" = "Ajustes…";
 "main_menu.quit" = "Salir de %@";
 

--- a/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 /* Main menu */
 "main_menu.about" = "À propos de %@";
+"main_menu.close_window" = "Fermer la fenêtre";
+"main_menu.file" = "Fichier";
 "main_menu.settings" = "Réglages…";
 "main_menu.quit" = "Quitter %@";
 

--- a/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 /* Main menu */
 "main_menu.about" = "%@について";
+"main_menu.close_window" = "ウインドウを閉じる";
+"main_menu.file" = "ファイル";
 "main_menu.settings" = "設定…";
 "main_menu.quit" = "%@を終了";
 

--- a/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 /* Main menu */
 "main_menu.about" = "Про %@";
+"main_menu.close_window" = "Закрити вікно";
+"main_menu.file" = "Файл";
 "main_menu.settings" = "Параметри…";
 "main_menu.quit" = "Завершити роботу %@";
 

--- a/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 /* Main menu */
 "main_menu.about" = "关于 %@";
+"main_menu.close_window" = "关闭窗口";
+"main_menu.file" = "文件";
 "main_menu.settings" = "设置…";
 "main_menu.quit" = "退出 %@";
 


### PR DESCRIPTION
## Summary

Localize the macOS File menu title and Close Window item in `MainMenu.swift` by routing them through the existing `L10n.MainMenu` accessors.

This also adds the corresponding `main_menu.file` and `main_menu.close_window` entries to each existing `Localizable.strings` locale so the synthesized localization API stays complete.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other:
  - `xcodebuild build -project Keyty.xcodeproj -scheme Keyty -configuration Debug`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Localized the File menu title and Close Window menu item in the macOS app menu.
