### PR TITLE
docs(readme): localize title links and center badges

### DIFF
--- a/Docs/README.de.md
+++ b/Docs/README.de.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://keyty.app">
+  <a href="https://keyty.app/de">
     <img src="../Assets/Application/AppIcon/AppIcon.png" alt="Logo der Keyty-App" width="128">
     <br />
     <strong>Keyty</strong>
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<div>
+<div align="center">
    <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="Versionen">
    <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="Downloads">
    <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="Sterne">

--- a/Docs/README.es.md
+++ b/Docs/README.es.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://keyty.app">
+  <a href="https://keyty.app/es">
     <img src="../Assets/Application/AppIcon/AppIcon.png" alt="Logotipo de la app Keyty" width="128">
     <br />
     <strong>Keyty</strong>
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<div>
+<div align="center">
    <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="Versiones">
    <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="Descargas">
    <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="Estrellas">

--- a/Docs/README.fr.md
+++ b/Docs/README.fr.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://keyty.app">
+  <a href="https://keyty.app/fr">
     <img src="../Assets/Application/AppIcon/AppIcon.png" alt="Logo de l'application Keyty" width="128">
     <br />
     <strong>Keyty</strong>
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<div>
+<div align="center">
    <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="Versions">
    <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="Téléchargements">
    <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="Étoiles">

--- a/Docs/README.ja.md
+++ b/Docs/README.ja.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://keyty.app">
+  <a href="https://keyty.app/ja">
     <img src="../Assets/Application/AppIcon/AppIcon.png" alt="Keyty アプリのロゴ" width="128">
     <br />
     <strong>Keyty</strong>
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<div>
+<div align="center">
    <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="リリース">
    <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="ダウンロード数">
    <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="スター">

--- a/Docs/README.uk.md
+++ b/Docs/README.uk.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://keyty.app">
+  <a href="https://keyty.app/uk">
     <img src="../Assets/Application/AppIcon/AppIcon.png" alt="Логотип програми Keyty" width="128">
     <br />
     <strong>Keyty</strong>
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<div>
+<div align="center">
    <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="Релізи">
    <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="Завантаження">
    <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="Зірки">

--- a/Docs/README.zh-Hans.md
+++ b/Docs/README.zh-Hans.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="https://keyty.app">
+  <a href="https://keyty.app/zh-Hans">
     <img src="../Assets/Application/AppIcon/AppIcon.png" alt="Keyty 应用标志" width="128">
     <br />
     <strong>Keyty</strong>
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<div>
+<div align="center">
    <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="版本">
    <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="下载量">
    <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="Star 数">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <br>
 </h1>
 
-<div>
+<div align="center">
    <img src="https://img.shields.io/github/v/release/keytyapp/Keyty?style=flat-square" alt="Releases">
    <img src="https://img.shields.io/github/downloads/keytyapp/Keyty/total?style=flat-square" alt="Downloads">
    <img src="https://img.shields.io/github/stars/keytyapp/Keyty?style=flat-square" alt="Stars">


### PR DESCRIPTION
## Summary

Update the main and localized README headers so translated title links go to their matching localized site routes, and center the badge row under the title.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Docs-only change; no tests run

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
