### PR TITLE
fix(ci): stop using secrets in workflow if guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,8 @@ jobs:
     if: ${{ !endsWith(github.ref_name, '-test') }}
     runs-on: ubuntu-latest
     needs: release
+    env:
+      HOMEBREW_TAP_DISPATCH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
 
     steps:
       - name: Download release artifacts
@@ -141,9 +143,9 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Dispatch Homebrew tap update
-        if: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN != '' }}
+        if: ${{ env.HOMEBREW_TAP_DISPATCH_TOKEN != '' }}
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ env.HOMEBREW_TAP_DISPATCH_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
@@ -163,5 +165,5 @@ jobs:
           EOF
 
       - name: Skip Homebrew tap update dispatch
-        if: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN == '' }}
+        if: ${{ env.HOMEBREW_TAP_DISPATCH_TOKEN == '' }}
         run: echo "::notice::Skipping Homebrew tap update dispatch because HOMEBREW_TAP_DISPATCH_TOKEN is not configured."


### PR DESCRIPTION
## Summary

Fix the release workflow validation error by stopping use of the `secrets` context inside step-level `if` guards in the Homebrew tap update job.

Why this changed:
GitHub Actions rejected the workflow because `secrets.HOMEBREW_TAP_DISPATCH_TOKEN` was referenced directly in step `if` expressions.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Workflow YAML change only; no local tests run

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Fix release workflow validation so optional Homebrew tap dispatch remains gated correctly when the dispatch token is unset.
