### PR TITLE
refactor(event-pipeline): simplify display event processing

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Domain/Events/MouseEvent.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Events/MouseEvent.swift
@@ -51,6 +51,10 @@ public struct MouseEvent {
         EventTransformer.shared.transform(inputEvent)
     }
 
+    public var hasZeroScrollDelta: Bool {
+        self.scrollingDeltaX == 0.0 && self.scrollingDeltaY == 0.0
+    }
+
     private static func screenLocation(from cgEvent: CGEvent) -> NSPoint {
         screenLocation(
             from: cgEvent.location,

--- a/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayEvent.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayEvent.swift
@@ -13,8 +13,7 @@ public enum DisplayEvent {
         text: String,
         sourceEvent: InputEvent,
         startsNewLine: Bool,
-        isModified: Bool,
-        isMouseEvent: Bool
+        isModified: Bool
     )
     case groupBreak
     case flagsChanged(NSEvent.ModifierFlags)

--- a/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayEvent.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayEvent.swift
@@ -9,12 +9,9 @@
 import AppKit
 
 public enum DisplayEvent {
-    case content(
-        text: String,
-        sourceEvent: InputEvent,
-        startsNewLine: Bool,
-        isModified: Bool
-    )
+    case keystroke(StandardKeyEvent)
+    case mouse(MouseEvent)
+    case mediaKey(MediaKeyEvent)
+    case modifierStateChanged(NSEvent.ModifierFlags)
     case groupBreak
-    case flagsChanged(NSEvent.ModifierFlags)
 }

--- a/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayEvent.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayEvent.swift
@@ -1,5 +1,5 @@
 //
-//  DisplayItem.swift
+//  DisplayEvent.swift
 //  Keyty
 //
 //  SPDX-FileCopyrightText: 2026 Serhii Bykov
@@ -8,7 +8,7 @@
 
 import AppKit
 
-public enum DisplayItem {
+public enum DisplayEvent {
     case content(
         text: String,
         sourceEvent: InputEvent,

--- a/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayItem.swift
+++ b/Apps/Keyty/Sources/Keyty/Domain/Models/DisplayItem.swift
@@ -8,61 +8,14 @@
 
 import AppKit
 
-public enum DisplayItemKind: Int {
-    case content
-    case groupBreak
-    case flagsChanged
-}
-
-public class DisplayItem {
-    public private(set) var kind: DisplayItemKind
-
-    public private(set) var text: String?
-    public private(set) var sourceEvent: InputEvent?
-    public private(set) var startsNewLine: Bool
-    public private(set) var isCommand: Bool
-    public private(set) var isModified: Bool
-    public private(set) var isMouseEvent: Bool
-
-    public private(set) var modifierFlags: NSEvent.ModifierFlags
-
-    public init(
-        asContentWithText text: String,
-        sourceEvent event: InputEvent?,
+public enum DisplayItem {
+    case content(
+        text: String,
+        sourceEvent: InputEvent,
         startsNewLine: Bool,
-        isCommand: Bool,
         isModified: Bool,
         isMouseEvent: Bool
-    ) {
-        self.kind = .content
-        self.text = text
-        self.sourceEvent = event
-        self.startsNewLine = startsNewLine
-        self.isCommand = isCommand
-        self.isModified = isModified
-        self.isMouseEvent = isMouseEvent
-        self.modifierFlags = []
-    }
-
-    public init(asGroupBreak: Void = ()) {
-        self.kind = .groupBreak
-        self.text = nil
-        self.sourceEvent = nil
-        self.startsNewLine = false
-        self.isCommand = false
-        self.isModified = false
-        self.isMouseEvent = false
-        self.modifierFlags = []
-    }
-
-    init(asFlagsChangedWith modifierFlags: NSEvent.ModifierFlags) {
-        self.kind = .flagsChanged
-        self.text = nil
-        self.sourceEvent = nil
-        self.startsNewLine = false
-        self.isCommand = false
-        self.isModified = false
-        self.isMouseEvent = false
-        self.modifierFlags = modifierFlags
-    }
+    )
+    case groupBreak
+    case flagsChanged(NSEvent.ModifierFlags)
 }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
@@ -69,62 +69,62 @@ final class KeyboardVisualizer {
             return
         }
 
-        if item.kind == .flagsChanged {
-            self.currentModifierFlags = item.modifierFlags
-            self.displayModifierPreview(item.modifierFlags)
+        switch item {
+        case .flagsChanged(let modifierFlags):
+            self.currentModifierFlags = modifierFlags
+            self.displayModifierPreview(modifierFlags)
             if self.hasPendingGroupBreak && self.currentTrackedFlags.isEmpty {
                 self.finishCurrentGroup(retaining: [])
             }
             return
-        }
 
-        if item.kind == .groupBreak {
+        case .groupBreak:
             if self.currentTrackedFlags.isEmpty {
                 self.finishCurrentGroup(retaining: [])
             } else {
                 self.hasPendingGroupBreak = true
             }
             return
-        }
 
-        guard let sourceEvent = item.sourceEvent else { return }
-        switch sourceEvent {
-        case .mouse(let mouseEvent):
-            guard self.visualizerSettings.showMouseEvents else { return }
-            self.prepareForNextContentEvent()
+        case .content(_, let sourceEvent, _, _, _):
+            switch sourceEvent {
+            case .mouse(let mouseEvent):
+                guard self.visualizerSettings.showMouseEvents else { return }
+                self.prepareForNextContentEvent()
 
-            let modifierItems = KeycapItemFactory.modifierItems(
-                currentFlags: mouseEvent.modifierFlags,
-                releasedFlags: [],
-                palette: self.visualizerSettings.palette
-            )
-            let keycap = KeycapItemFactory.mouseItem(for: mouseEvent, palette: self.visualizerSettings.palette)
-            self.eventCoordinator.handleMouseButton(
-                kind: mouseEvent.kind,
-                isPressed: keycap.isPressed,
-                items: modifierItems + [keycap],
-                appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
-                updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
-            )
-            return
+                let modifierItems = KeycapItemFactory.modifierItems(
+                    currentFlags: mouseEvent.modifierFlags,
+                    releasedFlags: [],
+                    palette: self.visualizerSettings.palette
+                )
+                let keycap = KeycapItemFactory.mouseItem(for: mouseEvent, palette: self.visualizerSettings.palette)
+                self.eventCoordinator.handleMouseButton(
+                    kind: mouseEvent.kind,
+                    isPressed: keycap.isPressed,
+                    items: modifierItems + [keycap],
+                    appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
+                    updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
+                )
+                return
 
-        case .mediaKey(let mediaKey):
-            guard self.visualizerSettings.showMediaKeyButtons else { return }
-            self.prepareForNextContentEvent()
+            case .mediaKey(let mediaKey):
+                guard self.visualizerSettings.showMediaKeyButtons else { return }
+                self.prepareForNextContentEvent()
 
-            let keycap = KeycapItemFactory.mediaKeyItem(for: mediaKey, palette: self.visualizerSettings.palette)
-            self.eventCoordinator.handleMediaKey(
-                kind: mediaKey.kind,
-                isPressed: keycap.isPressed,
-                items: [keycap],
-                appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
-                updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
-            )
-            return
+                let keycap = KeycapItemFactory.mediaKeyItem(for: mediaKey, palette: self.visualizerSettings.palette)
+                self.eventCoordinator.handleMediaKey(
+                    kind: mediaKey.kind,
+                    isPressed: keycap.isPressed,
+                    items: [keycap],
+                    appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
+                    updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
+                )
+                return
 
-        case .keystroke(let keystroke):
-            self.displayKeystroke(keystroke)
-            return
+            case .keystroke(let keystroke):
+                self.displayKeystroke(keystroke)
+                return
+            }
         }
     }
 

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
@@ -63,7 +63,7 @@ final class KeyboardVisualizer {
         self.updatePresentationState()
     }
 
-    func display(_ item: DisplayItem) {
+    func display(_ item: DisplayEvent) {
         guard self.visualizerSettings.isEnabled, self.isPresentationActive else {
             self.clearDisplayState()
             return

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
@@ -86,7 +86,7 @@ final class KeyboardVisualizer {
             }
             return
 
-        case .content(_, let sourceEvent, _, _, _):
+        case .content(_, let sourceEvent, _, _):
             switch sourceEvent {
             case .mouse(let mouseEvent):
                 guard self.visualizerSettings.showMouseEvents else { return }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
@@ -70,7 +70,7 @@ final class KeyboardVisualizer {
         }
 
         switch item {
-        case .flagsChanged(let modifierFlags):
+        case .modifierStateChanged(let modifierFlags):
             self.currentModifierFlags = modifierFlags
             self.displayModifierPreview(modifierFlags)
             if self.hasPendingGroupBreak && self.currentTrackedFlags.isEmpty {
@@ -86,45 +86,42 @@ final class KeyboardVisualizer {
             }
             return
 
-        case .content(_, let sourceEvent, _, _):
-            switch sourceEvent {
-            case .mouse(let mouseEvent):
-                guard self.visualizerSettings.showMouseEvents else { return }
-                self.prepareForNextContentEvent()
+        case .mouse(let mouseEvent):
+            guard self.visualizerSettings.showMouseEvents else { return }
+            self.prepareForNextContentEvent()
 
-                let modifierItems = KeycapItemFactory.modifierItems(
-                    currentFlags: mouseEvent.modifierFlags,
-                    releasedFlags: [],
-                    palette: self.visualizerSettings.palette
-                )
-                let keycap = KeycapItemFactory.mouseItem(for: mouseEvent, palette: self.visualizerSettings.palette)
-                self.eventCoordinator.handleMouseButton(
-                    kind: mouseEvent.kind,
-                    isPressed: keycap.isPressed,
-                    items: modifierItems + [keycap],
-                    appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
-                    updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
-                )
-                return
+            let modifierItems = KeycapItemFactory.modifierItems(
+                currentFlags: mouseEvent.modifierFlags,
+                releasedFlags: [],
+                palette: self.visualizerSettings.palette
+            )
+            let keycap = KeycapItemFactory.mouseItem(for: mouseEvent, palette: self.visualizerSettings.palette)
+            self.eventCoordinator.handleMouseButton(
+                kind: mouseEvent.kind,
+                isPressed: keycap.isPressed,
+                items: modifierItems + [keycap],
+                appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
+                updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
+            )
+            return
 
-            case .mediaKey(let mediaKey):
-                guard self.visualizerSettings.showMediaKeyButtons else { return }
-                self.prepareForNextContentEvent()
+        case .mediaKey(let mediaKey):
+            guard self.visualizerSettings.showMediaKeyButtons else { return }
+            self.prepareForNextContentEvent()
 
-                let keycap = KeycapItemFactory.mediaKeyItem(for: mediaKey, palette: self.visualizerSettings.palette)
-                self.eventCoordinator.handleMediaKey(
-                    kind: mediaKey.kind,
-                    isPressed: keycap.isPressed,
-                    items: [keycap],
-                    appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
-                    updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
-                )
-                return
+            let keycap = KeycapItemFactory.mediaKeyItem(for: mediaKey, palette: self.visualizerSettings.palette)
+            self.eventCoordinator.handleMediaKey(
+                kind: mediaKey.kind,
+                isPressed: keycap.isPressed,
+                items: [keycap],
+                appendGroup: { self.visualizerWindow.appendGroup(with: $0) },
+                updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
+            )
+            return
 
-            case .keystroke(let keystroke):
-                self.displayKeystroke(keystroke)
-                return
-            }
+        case .keystroke(let keystroke):
+            self.displayKeystroke(keystroke)
+            return
         }
     }
 

--- a/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
+++ b/Apps/Keyty/Sources/Keyty/Platform/Capture/CaptureController/CaptureController.swift
@@ -185,17 +185,17 @@ extension CaptureController: EventTapDelegate {
 
     func eventTap(_ tap: EventTap, noteKeystroke keystroke: StandardKeyEvent) {
         guard self.isCapturing else { return }
-        self.eventProcessor.noteKeystroke(keystroke)
+        self.eventProcessor.processKeystroke(keystroke)
     }
 
     func eventTap(_ tap: EventTap, noteFlagsChanged flags: NSEvent.ModifierFlags) {
         guard self.isCapturing else { return }
-        self.eventProcessor.noteFlagsChanged(flags)
+        self.eventProcessor.processFlagsChanged(flags)
     }
 
     func eventTap(_ tap: EventTap, noteMediaKey mediaKey: MediaKeyEvent) {
         guard self.isCapturing, mediaKey.isRecognized else { return }
-        self.eventProcessor.noteMediaKey(mediaKey)
+        self.eventProcessor.processMediaKey(mediaKey)
     }
 
     func eventTap(_ tap: EventTap, noteMouseEvent mouseEvent: MouseEvent) {
@@ -203,6 +203,6 @@ extension CaptureController: EventTapDelegate {
         Task { @MainActor [pointerVisualizersManager = self.pointerVisualizersManager] in
             pointerVisualizersManager.noteMouseEvent(mouseEvent)
         }
-        self.eventProcessor.noteMouseEvent(mouseEvent)
+        self.eventProcessor.processMouseEvent(mouseEvent)
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
@@ -24,8 +24,7 @@ public final class EventProcessor {
             text: keystroke.displayString,
             sourceEvent: keystroke.inputEvent,
             startsNewLine: keystroke.isCommand,
-            isModified: keystroke.isModified,
-            isMouseEvent: false
+            isModified: keystroke.isModified
         )
         onItemProduced?(item)
     }
@@ -41,8 +40,7 @@ public final class EventProcessor {
                 text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
-                isModified: false,
-                isMouseEvent: true
+                isModified: false
             )
             onItemProduced?(item)
             return
@@ -53,8 +51,7 @@ public final class EventProcessor {
                 text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
-                isModified: false,
-                isMouseEvent: true
+                isModified: false
             )
             onItemProduced?(item)
             onItemProduced?(.groupBreak)
@@ -69,8 +66,7 @@ public final class EventProcessor {
             text: mediaKey.displayString,
             sourceEvent: mediaKey.inputEvent,
             startsNewLine: false,
-            isModified: false,
-            isMouseEvent: false
+            isModified: false
         )
         onItemProduced?(item)
     }
@@ -106,8 +102,7 @@ public final class EventProcessor {
                 text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
-                isModified: false,
-                isMouseEvent: true
+                isModified: false
             )
             onItemProduced?(item)
         }

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
@@ -10,14 +10,9 @@ import AppKit
 
 public final class EventProcessor {
     var onItemProduced: ((DisplayEvent) -> Void)?
-
-    private enum ScrollState {
-        case idle
-        case active(displayed: Bool)
+    private lazy var scrollEventProcessor = ScrollEventProcessor { [weak self] item in
+        self?.onItemProduced?(item)
     }
-
-    private var scrollState = ScrollState.idle
-    private var scrollDebounceTimer: Timer?
 }
 
 // MARK: - Event Handlers
@@ -28,7 +23,7 @@ extension EventProcessor {
 
     func processMouseEvent(_ mouseEvent: MouseEvent) {
         if mouseEvent.type == .scrollWheel {
-            self.handleScrollEvent(mouseEvent)
+            self.scrollEventProcessor.process(mouseEvent)
             return
         }
 
@@ -50,60 +45,5 @@ extension EventProcessor {
 
     func processFlagsChanged(_ flags: NSEvent.ModifierFlags) {
         self.onItemProduced?(.modifierStateChanged(flags))
-    }
-}
-
-// MARK: - Scroll Events
-private extension EventProcessor {
-    func handleScrollEvent(_ mouseEvent: MouseEvent) {
-        let phase = mouseEvent.phase
-
-        if phase == .ended || phase == .cancelled {
-            self.finishScrollEvent()
-            return
-        }
-
-        if phase == .began {
-            self.scrollState = .active(displayed: false)
-            return
-        }
-
-        if mouseEvent.scrollingDeltaX == 0.0 && mouseEvent.scrollingDeltaY == 0.0 {
-            return
-        }
-
-        // Trackpad (precise): show bezel once per gesture, let phase events drive lifecycle.
-        // Scroll wheel (imprecise): update the bezel on every click so direction stays current.
-        let isWheel = !mouseEvent.hasPreciseScrollingDeltas
-        if self.shouldDisplayScrollBezel || isWheel {
-            self.scrollState = .active(displayed: true)
-            self.onItemProduced?(.mouse(mouseEvent))
-        }
-
-        if phase.isEmpty {
-            // Wheel events can be 100–200 ms apart; use a longer debounce so the
-            // timer does not fire between clicks and cause flicker.
-            let debounce: TimeInterval = isWheel ? 0.4 : 0.15
-            self.scrollDebounceTimer?.invalidate()
-            self.scrollDebounceTimer = Timer.scheduledTimer(withTimeInterval: debounce, repeats: false) { [weak self] _ in
-                self?.finishScrollEvent()
-            }
-        }
-    }
-
-    var shouldDisplayScrollBezel: Bool {
-        switch self.scrollState {
-        case .idle:
-            return true
-        case .active(displayed: let displayed):
-            return !displayed
-        }
-    }
-
-    func finishScrollEvent() {
-        self.scrollDebounceTimer?.invalidate()
-        self.scrollDebounceTimer = nil
-        self.scrollState = .idle
-        self.onItemProduced?(.groupBreak)
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
@@ -9,7 +9,7 @@
 import AppKit
 
 public final class EventProcessor {
-    var onItemProduced: ((DisplayItem) -> Void)?
+    var onItemProduced: ((DisplayEvent) -> Void)?
 
     private enum ScrollState {
         case idle
@@ -20,7 +20,7 @@ public final class EventProcessor {
     private var scrollDebounceTimer: Timer?
 
     func noteKeystroke(_ keystroke: StandardKeyEvent) {
-        let item = DisplayItem.content(
+        let item = DisplayEvent.content(
             text: keystroke.displayString,
             sourceEvent: keystroke.inputEvent,
             startsNewLine: keystroke.isCommand,
@@ -37,7 +37,7 @@ public final class EventProcessor {
         }
 
         if [.leftMouseDown, .rightMouseDown, .otherMouseDown].contains(mouseEvent.type) {
-            let item = DisplayItem.content(
+            let item = DisplayEvent.content(
                 text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
@@ -49,7 +49,7 @@ public final class EventProcessor {
         }
 
         if [.leftMouseUp, .rightMouseUp, .otherMouseUp].contains(mouseEvent.type) {
-            let item = DisplayItem.content(
+            let item = DisplayEvent.content(
                 text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
@@ -65,7 +65,7 @@ public final class EventProcessor {
     }
 
     func noteMediaKey(_ mediaKey: MediaKeyEvent) {
-        let item = DisplayItem.content(
+        let item = DisplayEvent.content(
             text: mediaKey.displayString,
             sourceEvent: mediaKey.inputEvent,
             startsNewLine: false,
@@ -76,7 +76,7 @@ public final class EventProcessor {
     }
 
     func noteFlagsChanged(_ flags: NSEvent.ModifierFlags) {
-        let item = DisplayItem.flagsChanged(flags)
+        let item = DisplayEvent.flagsChanged(flags)
         onItemProduced?(item)
     }
 
@@ -102,7 +102,7 @@ public final class EventProcessor {
         let isWheel = !mouseEvent.hasPreciseScrollingDeltas
         if shouldDisplayScrollBezel || isWheel {
             scrollState = .active(displayed: true)
-            let item = DisplayItem.content(
+            let item = DisplayEvent.content(
                 text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
@@ -20,13 +20,7 @@ public final class EventProcessor {
     private var scrollDebounceTimer: Timer?
 
     func noteKeystroke(_ keystroke: StandardKeyEvent) {
-        let item = DisplayEvent.content(
-            text: keystroke.displayString,
-            sourceEvent: keystroke.inputEvent,
-            startsNewLine: keystroke.isCommand,
-            isModified: keystroke.isModified
-        )
-        onItemProduced?(item)
+        onItemProduced?(.keystroke(keystroke))
     }
 
     func noteMouseEvent(_ mouseEvent: MouseEvent) {
@@ -36,24 +30,12 @@ public final class EventProcessor {
         }
 
         if [.leftMouseDown, .rightMouseDown, .otherMouseDown].contains(mouseEvent.type) {
-            let item = DisplayEvent.content(
-                text: mouseEvent.displayString,
-                sourceEvent: mouseEvent.inputEvent,
-                startsNewLine: true,
-                isModified: false
-            )
-            onItemProduced?(item)
+            onItemProduced?(.mouse(mouseEvent))
             return
         }
 
         if [.leftMouseUp, .rightMouseUp, .otherMouseUp].contains(mouseEvent.type) {
-            let item = DisplayEvent.content(
-                text: mouseEvent.displayString,
-                sourceEvent: mouseEvent.inputEvent,
-                startsNewLine: true,
-                isModified: false
-            )
-            onItemProduced?(item)
+            onItemProduced?(.mouse(mouseEvent))
             onItemProduced?(.groupBreak)
             return
         }
@@ -62,18 +44,11 @@ public final class EventProcessor {
     }
 
     func noteMediaKey(_ mediaKey: MediaKeyEvent) {
-        let item = DisplayEvent.content(
-            text: mediaKey.displayString,
-            sourceEvent: mediaKey.inputEvent,
-            startsNewLine: false,
-            isModified: false
-        )
-        onItemProduced?(item)
+        onItemProduced?(.mediaKey(mediaKey))
     }
 
     func noteFlagsChanged(_ flags: NSEvent.ModifierFlags) {
-        let item = DisplayEvent.flagsChanged(flags)
-        onItemProduced?(item)
+        onItemProduced?(.modifierStateChanged(flags))
     }
 
     private func handleScrollEvent(_ mouseEvent: MouseEvent) {
@@ -98,13 +73,7 @@ public final class EventProcessor {
         let isWheel = !mouseEvent.hasPreciseScrollingDeltas
         if shouldDisplayScrollBezel || isWheel {
             scrollState = .active(displayed: true)
-            let item = DisplayEvent.content(
-                text: mouseEvent.displayString,
-                sourceEvent: mouseEvent.inputEvent,
-                startsNewLine: true,
-                isModified: false
-            )
-            onItemProduced?(item)
+            onItemProduced?(.mouse(mouseEvent))
         }
 
         if phase.isEmpty {

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
@@ -18,49 +18,53 @@ public final class EventProcessor {
 
     private var scrollState = ScrollState.idle
     private var scrollDebounceTimer: Timer?
+}
 
-    func noteKeystroke(_ keystroke: StandardKeyEvent) {
-        onItemProduced?(.keystroke(keystroke))
+// MARK: - Event Handlers
+extension EventProcessor {
+    func processKeystroke(_ keystroke: StandardKeyEvent) {
+        self.onItemProduced?(.keystroke(keystroke))
     }
 
-    func noteMouseEvent(_ mouseEvent: MouseEvent) {
+    func processMouseEvent(_ mouseEvent: MouseEvent) {
         if mouseEvent.type == .scrollWheel {
-            handleScrollEvent(mouseEvent)
+            self.handleScrollEvent(mouseEvent)
             return
         }
 
         if [.leftMouseDown, .rightMouseDown, .otherMouseDown].contains(mouseEvent.type) {
-            onItemProduced?(.mouse(mouseEvent))
+            self.onItemProduced?(.mouse(mouseEvent))
             return
         }
 
         if [.leftMouseUp, .rightMouseUp, .otherMouseUp].contains(mouseEvent.type) {
-            onItemProduced?(.mouse(mouseEvent))
-            onItemProduced?(.groupBreak)
+            self.onItemProduced?(.mouse(mouseEvent))
+            self.onItemProduced?(.groupBreak)
             return
         }
-
-        // Drags discarded.
     }
 
-    func noteMediaKey(_ mediaKey: MediaKeyEvent) {
-        onItemProduced?(.mediaKey(mediaKey))
+    func processMediaKey(_ mediaKey: MediaKeyEvent) {
+        self.onItemProduced?(.mediaKey(mediaKey))
     }
 
-    func noteFlagsChanged(_ flags: NSEvent.ModifierFlags) {
-        onItemProduced?(.modifierStateChanged(flags))
+    func processFlagsChanged(_ flags: NSEvent.ModifierFlags) {
+        self.onItemProduced?(.modifierStateChanged(flags))
     }
+}
 
-    private func handleScrollEvent(_ mouseEvent: MouseEvent) {
+// MARK: - Scroll Events
+private extension EventProcessor {
+    func handleScrollEvent(_ mouseEvent: MouseEvent) {
         let phase = mouseEvent.phase
 
         if phase == .ended || phase == .cancelled {
-            finishScrollEvent()
+            self.finishScrollEvent()
             return
         }
 
         if phase == .began {
-            scrollState = .active(displayed: false)
+            self.scrollState = .active(displayed: false)
             return
         }
 
@@ -71,24 +75,24 @@ public final class EventProcessor {
         // Trackpad (precise): show bezel once per gesture, let phase events drive lifecycle.
         // Scroll wheel (imprecise): update the bezel on every click so direction stays current.
         let isWheel = !mouseEvent.hasPreciseScrollingDeltas
-        if shouldDisplayScrollBezel || isWheel {
-            scrollState = .active(displayed: true)
-            onItemProduced?(.mouse(mouseEvent))
+        if self.shouldDisplayScrollBezel || isWheel {
+            self.scrollState = .active(displayed: true)
+            self.onItemProduced?(.mouse(mouseEvent))
         }
 
         if phase.isEmpty {
             // Wheel events can be 100–200 ms apart; use a longer debounce so the
             // timer does not fire between clicks and cause flicker.
             let debounce: TimeInterval = isWheel ? 0.4 : 0.15
-            scrollDebounceTimer?.invalidate()
-            scrollDebounceTimer = Timer.scheduledTimer(withTimeInterval: debounce, repeats: false) { [weak self] _ in
+            self.scrollDebounceTimer?.invalidate()
+            self.scrollDebounceTimer = Timer.scheduledTimer(withTimeInterval: debounce, repeats: false) { [weak self] _ in
                 self?.finishScrollEvent()
             }
         }
     }
 
-    private var shouldDisplayScrollBezel: Bool {
-        switch scrollState {
+    var shouldDisplayScrollBezel: Bool {
+        switch self.scrollState {
         case .idle:
             return true
         case .active(displayed: let displayed):
@@ -96,10 +100,10 @@ public final class EventProcessor {
         }
     }
 
-    private func finishScrollEvent() {
-        scrollDebounceTimer?.invalidate()
-        scrollDebounceTimer = nil
-        scrollState = .idle
-        onItemProduced?(.groupBreak)
+    func finishScrollEvent() {
+        self.scrollDebounceTimer?.invalidate()
+        self.scrollDebounceTimer = nil
+        self.scrollState = .idle
+        self.onItemProduced?(.groupBreak)
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/EventProcessor.swift
@@ -20,11 +20,10 @@ public final class EventProcessor {
     private var scrollDebounceTimer: Timer?
 
     func noteKeystroke(_ keystroke: StandardKeyEvent) {
-        let item = DisplayItem(
-            asContentWithText: keystroke.displayString,
+        let item = DisplayItem.content(
+            text: keystroke.displayString,
             sourceEvent: keystroke.inputEvent,
             startsNewLine: keystroke.isCommand,
-            isCommand: keystroke.isCommand,
             isModified: keystroke.isModified,
             isMouseEvent: false
         )
@@ -38,11 +37,10 @@ public final class EventProcessor {
         }
 
         if [.leftMouseDown, .rightMouseDown, .otherMouseDown].contains(mouseEvent.type) {
-            let item = DisplayItem(
-                asContentWithText: mouseEvent.displayString,
+            let item = DisplayItem.content(
+                text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
-                isCommand: false,
                 isModified: false,
                 isMouseEvent: true
             )
@@ -51,16 +49,15 @@ public final class EventProcessor {
         }
 
         if [.leftMouseUp, .rightMouseUp, .otherMouseUp].contains(mouseEvent.type) {
-            let item = DisplayItem(
-                asContentWithText: mouseEvent.displayString,
+            let item = DisplayItem.content(
+                text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
-                isCommand: false,
                 isModified: false,
                 isMouseEvent: true
             )
             onItemProduced?(item)
-            onItemProduced?(DisplayItem(asGroupBreak: ()))
+            onItemProduced?(.groupBreak)
             return
         }
 
@@ -68,11 +65,10 @@ public final class EventProcessor {
     }
 
     func noteMediaKey(_ mediaKey: MediaKeyEvent) {
-        let item = DisplayItem(
-            asContentWithText: mediaKey.displayString,
+        let item = DisplayItem.content(
+            text: mediaKey.displayString,
             sourceEvent: mediaKey.inputEvent,
             startsNewLine: false,
-            isCommand: false,
             isModified: false,
             isMouseEvent: false
         )
@@ -80,7 +76,7 @@ public final class EventProcessor {
     }
 
     func noteFlagsChanged(_ flags: NSEvent.ModifierFlags) {
-        let item = DisplayItem(asFlagsChangedWith: flags)
+        let item = DisplayItem.flagsChanged(flags)
         onItemProduced?(item)
     }
 
@@ -106,11 +102,10 @@ public final class EventProcessor {
         let isWheel = !mouseEvent.hasPreciseScrollingDeltas
         if shouldDisplayScrollBezel || isWheel {
             scrollState = .active(displayed: true)
-            let item = DisplayItem(
-                asContentWithText: mouseEvent.displayString,
+            let item = DisplayItem.content(
+                text: mouseEvent.displayString,
                 sourceEvent: mouseEvent.inputEvent,
                 startsNewLine: true,
-                isCommand: false,
                 isModified: false,
                 isMouseEvent: true
             )
@@ -141,6 +136,6 @@ public final class EventProcessor {
         scrollDebounceTimer?.invalidate()
         scrollDebounceTimer = nil
         scrollState = .idle
-        onItemProduced?(DisplayItem(asGroupBreak: ()))
+        onItemProduced?(.groupBreak)
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/ScrollEventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/ScrollEventProcessor.swift
@@ -1,0 +1,77 @@
+//
+//  ScrollEventProcessor.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import AppKit
+
+final class ScrollEventProcessor {
+    private enum ScrollState {
+        case idle
+        case active(displayed: Bool)
+    }
+
+    private let emit: (DisplayEvent) -> Void
+
+    private var scrollState = ScrollState.idle
+    private var scrollDebounceTimer: Timer?
+
+    init(emit: @escaping (DisplayEvent) -> Void) {
+        self.emit = emit
+    }
+
+    func process(_ mouseEvent: MouseEvent) {
+        let phase = mouseEvent.phase
+
+        if phase == .ended || phase == .cancelled {
+            self.finishScrollEvent()
+            return
+        }
+
+        if phase == .began {
+            self.scrollState = .active(displayed: false)
+            return
+        }
+
+        if mouseEvent.scrollingDeltaX == 0.0 && mouseEvent.scrollingDeltaY == 0.0 {
+            return
+        }
+
+        // Trackpad (precise): show bezel once per gesture, let phase events drive lifecycle.
+        // Scroll wheel (imprecise): update the bezel on every click so direction stays current.
+        let isWheel = !mouseEvent.hasPreciseScrollingDeltas
+        if self.shouldDisplayScrollBezel || isWheel {
+            self.scrollState = .active(displayed: true)
+            self.emit(.mouse(mouseEvent))
+        }
+
+        if phase.isEmpty {
+            // Wheel events can be 100–200 ms apart; use a longer debounce so the
+            // timer does not fire between clicks and cause flicker.
+            let debounce: TimeInterval = isWheel ? 0.4 : 0.15
+            self.scrollDebounceTimer?.invalidate()
+            self.scrollDebounceTimer = Timer.scheduledTimer(withTimeInterval: debounce, repeats: false) { [weak self] _ in
+                self?.finishScrollEvent()
+            }
+        }
+    }
+
+    private var shouldDisplayScrollBezel: Bool {
+        switch self.scrollState {
+        case .idle:
+            return true
+        case .active(displayed: let displayed):
+            return !displayed
+        }
+    }
+
+    private func finishScrollEvent() {
+        self.scrollDebounceTimer?.invalidate()
+        self.scrollDebounceTimer = nil
+        self.scrollState = .idle
+        self.emit(.groupBreak)
+    }
+}

--- a/Apps/Keyty/Sources/Keyty/Services/EventPipeline/ScrollEventProcessor.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/EventPipeline/ScrollEventProcessor.swift
@@ -9,18 +9,18 @@
 import AppKit
 
 final class ScrollEventProcessor {
-    private enum ScrollState {
+    private enum State {
         case idle
         case active(displayed: Bool)
     }
 
-    private let emit: (DisplayEvent) -> Void
+    private let onItemProduced: (DisplayEvent) -> Void
 
-    private var scrollState = ScrollState.idle
-    private var scrollDebounceTimer: Timer?
+    private var state = State.idle
+    private var debounceTimer: Timer?
 
-    init(emit: @escaping (DisplayEvent) -> Void) {
-        self.emit = emit
+    init(onItemProduced: @escaping (DisplayEvent) -> Void) {
+        self.onItemProduced = onItemProduced
     }
 
     func process(_ mouseEvent: MouseEvent) {
@@ -32,11 +32,11 @@ final class ScrollEventProcessor {
         }
 
         if phase == .began {
-            self.scrollState = .active(displayed: false)
+            self.state = .active(displayed: false)
             return
         }
 
-        if mouseEvent.scrollingDeltaX == 0.0 && mouseEvent.scrollingDeltaY == 0.0 {
+        if mouseEvent.hasZeroScrollDelta {
             return
         }
 
@@ -44,23 +44,23 @@ final class ScrollEventProcessor {
         // Scroll wheel (imprecise): update the bezel on every click so direction stays current.
         let isWheel = !mouseEvent.hasPreciseScrollingDeltas
         if self.shouldDisplayScrollBezel || isWheel {
-            self.scrollState = .active(displayed: true)
-            self.emit(.mouse(mouseEvent))
+            self.state = .active(displayed: true)
+            self.onItemProduced(.mouse(mouseEvent))
         }
 
         if phase.isEmpty {
             // Wheel events can be 100–200 ms apart; use a longer debounce so the
             // timer does not fire between clicks and cause flicker.
             let debounce: TimeInterval = isWheel ? 0.4 : 0.15
-            self.scrollDebounceTimer?.invalidate()
-            self.scrollDebounceTimer = Timer.scheduledTimer(withTimeInterval: debounce, repeats: false) { [weak self] _ in
+            self.debounceTimer?.invalidate()
+            self.debounceTimer = Timer.scheduledTimer(withTimeInterval: debounce, repeats: false) { [weak self] _ in
                 self?.finishScrollEvent()
             }
         }
     }
 
     private var shouldDisplayScrollBezel: Bool {
-        switch self.scrollState {
+        switch self.state {
         case .idle:
             return true
         case .active(displayed: let displayed):
@@ -69,9 +69,9 @@ final class ScrollEventProcessor {
     }
 
     private func finishScrollEvent() {
-        self.scrollDebounceTimer?.invalidate()
-        self.scrollDebounceTimer = nil
-        self.scrollState = .idle
-        self.emit(.groupBreak)
+        self.debounceTimer?.invalidate()
+        self.debounceTimer = nil
+        self.state = .idle
+        self.onItemProduced(.groupBreak)
     }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
@@ -49,14 +49,7 @@ final class KeyboardVisualizerTests: XCTestCase {
             characters: "k",
             charactersIgnoringModifiers: "k"
         )
-        self.visualizer.display(
-            .content(
-                text: keystroke.displayString,
-                sourceEvent: keystroke.inputEvent,
-                startsNewLine: false,
-                isModified: keystroke.isModified
-            )
-        )
+        self.visualizer.display(.keystroke(keystroke))
 
         XCTAssertEqual(self.visualizer.visibleGroupCount, 1)
 

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
@@ -54,8 +54,7 @@ final class KeyboardVisualizerTests: XCTestCase {
                 text: keystroke.displayString,
                 sourceEvent: keystroke.inputEvent,
                 startsNewLine: false,
-                isModified: keystroke.isModified,
-                isMouseEvent: false
+                isModified: keystroke.isModified
             )
         )
 

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
@@ -50,11 +50,10 @@ final class KeyboardVisualizerTests: XCTestCase {
             charactersIgnoringModifiers: "k"
         )
         self.visualizer.display(
-            DisplayItem(
-                asContentWithText: keystroke.displayString,
+            .content(
+                text: keystroke.displayString,
                 sourceEvent: keystroke.inputEvent,
                 startsNewLine: false,
-                isCommand: keystroke.isCommand,
                 isModified: keystroke.isModified,
                 isMouseEvent: false
             )

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class EventProcessorTests: XCTestCase {
     func testMouseUpEmitsContentAndGroupBreakWhenModifierIsHeld() {
         let processor = EventProcessor()
-        var items: [DisplayItem] = []
+        var items: [DisplayEvent] = []
         processor.onItemProduced = { items.append($0) }
 
         processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: [.command]))
@@ -35,7 +35,7 @@ final class EventProcessorTests: XCTestCase {
 
     func testMouseUpWithoutModifiersEmitsContentAndGroupBreak() {
         let processor = EventProcessor()
-        var items: [DisplayItem] = []
+        var items: [DisplayEvent] = []
         processor.onItemProduced = { items.append($0) }
 
         processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: []))

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
@@ -18,9 +18,19 @@ final class EventProcessorTests: XCTestCase {
         processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: [.command]))
 
         XCTAssertEqual(items.count, 2)
-        XCTAssertEqual(items[0].kind, .content)
-        XCTAssertEqual(items[0].sourceEvent?.type, .leftMouseUp)
-        XCTAssertEqual(items[1].kind, .groupBreak)
+        switch items[0] {
+        case .content(_, let sourceEvent, _, _, _):
+            XCTAssertEqual(sourceEvent.type, .leftMouseUp)
+        default:
+            XCTFail("Expected content item")
+        }
+
+        switch items[1] {
+        case .groupBreak:
+            break
+        default:
+            XCTFail("Expected group break item")
+        }
     }
 
     func testMouseUpWithoutModifiersEmitsContentAndGroupBreak() {
@@ -31,9 +41,18 @@ final class EventProcessorTests: XCTestCase {
         processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: []))
 
         XCTAssertEqual(items.count, 2)
-        XCTAssertEqual(items[0].kind, .content)
-        XCTAssertEqual(items[0].sourceEvent?.type, .leftMouseUp)
-        XCTAssertEqual(items[1].kind, .groupBreak)
-    }
+        switch items[0] {
+        case .content(_, let sourceEvent, _, _, _):
+            XCTAssertEqual(sourceEvent.type, .leftMouseUp)
+        default:
+            XCTFail("Expected content item")
+        }
 
+        switch items[1] {
+        case .groupBreak:
+            break
+        default:
+            XCTFail("Expected group break item")
+        }
+    }
 }

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
@@ -19,7 +19,7 @@ final class EventProcessorTests: XCTestCase {
 
         XCTAssertEqual(items.count, 2)
         switch items[0] {
-        case .content(_, let sourceEvent, _, _, _):
+        case .content(_, let sourceEvent, _, _):
             XCTAssertEqual(sourceEvent.type, .leftMouseUp)
         default:
             XCTFail("Expected content item")
@@ -42,7 +42,7 @@ final class EventProcessorTests: XCTestCase {
 
         XCTAssertEqual(items.count, 2)
         switch items[0] {
-        case .content(_, let sourceEvent, _, _, _):
+        case .content(_, let sourceEvent, _, _):
             XCTAssertEqual(sourceEvent.type, .leftMouseUp)
         default:
             XCTFail("Expected content item")

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
@@ -15,7 +15,7 @@ final class EventProcessorTests: XCTestCase {
         var items: [DisplayEvent] = []
         processor.onItemProduced = { items.append($0) }
 
-        processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: [.command]))
+        processor.processMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: [.command]))
 
         XCTAssertEqual(items.count, 2)
         switch items[0] {
@@ -38,7 +38,7 @@ final class EventProcessorTests: XCTestCase {
         var items: [DisplayEvent] = []
         processor.onItemProduced = { items.append($0) }
 
-        processor.noteMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: []))
+        processor.processMouseEvent(TestMouseEvents.make(type: .leftMouseUp, buttonNumber: 0, modifiers: []))
 
         XCTAssertEqual(items.count, 2)
         switch items[0] {

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventProcessorTests.swift
@@ -19,10 +19,10 @@ final class EventProcessorTests: XCTestCase {
 
         XCTAssertEqual(items.count, 2)
         switch items[0] {
-        case .content(_, let sourceEvent, _, _):
-            XCTAssertEqual(sourceEvent.type, .leftMouseUp)
+        case .mouse(let mouseEvent):
+            XCTAssertEqual(mouseEvent.type, .leftMouseUp)
         default:
-            XCTFail("Expected content item")
+            XCTFail("Expected mouse event")
         }
 
         switch items[1] {
@@ -42,10 +42,10 @@ final class EventProcessorTests: XCTestCase {
 
         XCTAssertEqual(items.count, 2)
         switch items[0] {
-        case .content(_, let sourceEvent, _, _):
-            XCTAssertEqual(sourceEvent.type, .leftMouseUp)
+        case .mouse(let mouseEvent):
+            XCTAssertEqual(mouseEvent.type, .leftMouseUp)
         default:
-            XCTFail("Expected content item")
+            XCTFail("Expected mouse event")
         }
 
         switch items[1] {


### PR DESCRIPTION
## Summary

Refactor the display event pipeline to use typed `DisplayEvent` cases instead of the old `DisplayItem` content payload shape.

Extract scroll-wheel handling into `ScrollEventProcessor` so `EventProcessor` stays focused on routing input events into display events.

Clean up the event pipeline naming and supporting helpers, including the `EventProcessor` entry points and a `MouseEvent.hasZeroScrollDelta` helper used by scroll processing.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other:
  Focused verification with `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/EventProcessorTests`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A
