### PR TITLE
feat(displays): add custom anchor content alignment

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
@@ -94,15 +94,33 @@ struct DisplaysSettingsPane: View {
 
 private extension DisplaysSettingsPane {
     var customPlacementControls: some View {
-        SettingsControlRow(
-            title: L10n.Displays.CustomPosition.label,
-            subtitle: L10n.Displays.CustomPosition.setSubtitle
-        ) {
-            Button(self.model.isSettingCustomPosition ? L10n.Displays.CustomPosition.stopSettingButton : L10n.Displays.CustomPosition.startSettingButton) {
-                self.model.toggleCustomPositionSetting()
+        Group {
+            SettingsControlRow(
+                title: L10n.Displays.CustomPosition.label,
+                subtitle: L10n.Displays.CustomPosition.setSubtitle
+            ) {
+                Button(self.model.isSettingCustomPosition ? L10n.Displays.CustomPosition.stopSettingButton : L10n.Displays.CustomPosition.startSettingButton) {
+                    self.model.toggleCustomPositionSetting()
+                }
+                .controlSize(.regular)
+                .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
             }
-            .controlSize(.regular)
-            .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
+
+            Divider()
+
+            SettingsControlRow(
+                title: L10n.Displays.customContentAlignmentLabel,
+                subtitle: L10n.Displays.customContentAlignmentSubtitle
+            ) {
+                Picker("", selection: self.$model.customHorizontalAlignment) {
+                    ForEach(KeyboardVisualizerAlignment.allCases, id: \.rawValue) { alignment in
+                        Text(alignment.label).tag(alignment)
+                    }
+                }
+                .labelsHidden()
+                .accessibilityLabel(L10n.Displays.customContentAlignmentLabel)
+                .frame(width: Size.Control.settingsPickerWidth, alignment: .trailing)
+            }
         }
     }
 

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPaneViewModel.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPaneViewModel.swift
@@ -57,6 +57,13 @@ final class DisplaysSettingsPaneViewModel: ObservableObject {
         didSet { self.keyboardVisualizerSettings.customPositionNormalizedY = CGFloat(self.customPositionNormalizedY) }
     }
 
+    @Published var customHorizontalAlignment: KeyboardVisualizerAlignment {
+        didSet {
+            guard self.keyboardVisualizerSettings.customHorizontalAlignment != self.customHorizontalAlignment else { return }
+            self.keyboardVisualizerSettings.customHorizontalAlignment = self.customHorizontalAlignment
+        }
+    }
+
     @Published private(set) var stackAxis: KeyboardVisualizerStackAxis
     @Published private(set) var scale: Double
 
@@ -108,6 +115,7 @@ final class DisplaysSettingsPaneViewModel: ObservableObject {
         self.windowPadding = Double(keyboardVisualizerSettings.windowPadding)
         self.customPositionNormalizedX = Double(keyboardVisualizerSettings.customPositionNormalizedX)
         self.customPositionNormalizedY = Double(keyboardVisualizerSettings.customPositionNormalizedY)
+        self.customHorizontalAlignment = keyboardVisualizerSettings.customHorizontalAlignment
         self.stackAxis = keyboardVisualizerSettings.stackAxis
         self.scale = Double(keyboardVisualizerSettings.scale)
 
@@ -126,6 +134,7 @@ final class DisplaysSettingsPaneViewModel: ObservableObject {
                 guard let self, let keyboardVisualizerSettings else { return }
                 self.stackAxis = keyboardVisualizerSettings.stackAxis
                 self.scale = Double(keyboardVisualizerSettings.scale)
+                self.customHorizontalAlignment = keyboardVisualizerSettings.customHorizontalAlignment
             }
             .store(in: &self.cancellables)
     }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerAlignment.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerAlignment.swift
@@ -8,11 +8,22 @@
 
 /// Aligns groups on the cross axis of a `KeyboardVisualizerStackAxis`.
 /// The same cases map to left/center/right or bottom/center/top depending on stack direction.
-enum KeyboardVisualizerAlignment: Int {
+enum KeyboardVisualizerAlignment: Int, CaseIterable {
     /// Pinned to the cross-axis start (left for a vertical stack, bottom for a horizontal stack).
     case leading = 0
     /// Centered on the cross axis.
     case center = 1
     /// Pinned to the cross-axis end (right for a vertical stack, top for a horizontal stack).
     case trailing = 2
+
+    var label: String {
+        switch self {
+        case .leading:
+            L10n.Anchor.left
+        case .center:
+            L10n.Anchor.center
+        case .trailing:
+            L10n.Anchor.right
+        }
+    }
 }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerPlacementWindowController.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerPlacementWindowController.swift
@@ -54,7 +54,8 @@ extension KeyboardVisualizerPlacementWindowController {
         let frame = Self.frame(
             forNormalizedPosition: CGPoint(x: self.settings.customPositionNormalizedX, y: self.settings.customPositionNormalizedY),
             in: visibleFrame,
-            size: size
+            size: size,
+            horizontalAlignment: self.previewHorizontalAlignment
         )
         let window = Window(frame: frame, contentView: contentView)
         window.onMoveEnded = { [weak self] in
@@ -67,7 +68,7 @@ extension KeyboardVisualizerPlacementWindowController {
     func stopSettingPosition() -> Placement? {
         guard let window = self.window else { return nil }
 
-        let placement = self.placement(for: CGPoint(x: window.frame.midX, y: window.frame.midY))
+        let placement = self.placement(for: self.previewAnchorPoint(in: window.frame))
         window.close()
         self.onPlacementChanged = nil
         self.window = nil
@@ -79,14 +80,19 @@ extension KeyboardVisualizerPlacementWindowController {
     static func frame(
         forNormalizedPosition position: CGPoint,
         in area: CGRect,
-        size: CGSize
+        size: CGSize,
+        horizontalAlignment: KeyboardVisualizerAlignment = .center
     ) -> CGRect {
         let center = CGPoint(
             x: area.minX + area.width * position.x,
             y: area.minY + area.height * position.y
         )
         let origin = CGPoint(
-            x: (center.x - size.width / 2).clamped(minimum: area.minX, maximum: area.maxX - size.width),
+            x: KeyboardVisualizerWindow.customHorizontalOriginX(
+                for: size.width,
+                anchoredAt: center.x,
+                alignment: horizontalAlignment
+            ).clamped(minimum: area.minX, maximum: area.maxX - size.width),
             y: (center.y - size.height / 2).clamped(minimum: area.minY, maximum: area.maxY - size.height)
         )
 
@@ -124,6 +130,17 @@ extension KeyboardVisualizerPlacementWindowController {
             Self.previewItem(keyCode: .t, symbol: "T", settings: settings),
         ]
     }
+
+    static func anchorX(in frame: CGRect, alignment: KeyboardVisualizerAlignment) -> CGFloat {
+        switch alignment {
+        case .leading:
+            return frame.minX
+        case .center:
+            return frame.midX
+        case .trailing:
+            return frame.maxX
+        }
+    }
 }
 
 private extension KeyboardVisualizerPlacementWindowController {
@@ -147,18 +164,34 @@ private extension KeyboardVisualizerPlacementWindowController {
             ?? self.screensService.mainVisibleFrame()
     }
 
+    var previewHorizontalAlignment: KeyboardVisualizerAlignment {
+        switch self.settings.stackAxis {
+        case .vertical:
+            return self.settings.customHorizontalAlignment
+        case .horizontal:
+            return .center
+        }
+    }
+
     func placement(for point: CGPoint) -> Placement? {
         Self.placement(for: point, in: self.visibleFrames())
     }
 
     func notifyPlacementChanged() {
         guard let window = self.window,
-              let placement = self.placement(for: CGPoint(x: window.frame.midX, y: window.frame.midY))
+              let placement = self.placement(for: self.previewAnchorPoint(in: window.frame))
         else {
             return
         }
 
         self.onPlacementChanged?(placement)
+    }
+
+    func previewAnchorPoint(in frame: CGRect) -> CGPoint {
+        CGPoint(
+            x: Self.anchorX(in: frame, alignment: self.previewHorizontalAlignment),
+            y: frame.midY
+        )
     }
 
     func visibleFrames() -> [(screenID: CGDirectDisplayID, frame: CGRect)] {

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettings.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettings.swift
@@ -36,6 +36,8 @@ protocol KeyboardVisualizerSettingsProtocol: AnyObject {
     var customPositionNormalizedX: CGFloat { get set }
     /// Vertical custom overlay position normalized to the selected display visible frame.
     var customPositionNormalizedY: CGFloat { get set }
+    /// Horizontal alignment used when custom placement is selected.
+    var customHorizontalAlignment: KeyboardVisualizerAlignment { get set }
 
     var screenID: CGDirectDisplayID { get set }
     var scale: CGFloat { get set }
@@ -106,11 +108,19 @@ final class KeyboardVisualizerSettings: KeyboardVisualizerSettingsProtocol, HasS
     ))
     var stackAxis: KeyboardVisualizerStackAxis
 
-    /// Cross-axis alignment, derived from the anchor so groups hug the same edge the
-    /// window is pinned to. The cross axis depends on the stacking axis: a vertical
-    /// stack uses the anchor's horizontal side; a horizontal stack uses its vertical side
-    /// (where AppKit y grows upward, so `.top` maps to `.trailing` and `.bottom` to `.leading`).
+    /// Cross-axis alignment used by group layout. Preset anchors derive this from the
+    /// pinned edge; custom placement uses an explicit horizontal alignment only for
+    /// vertical stacks, while horizontal stacks remain vertically centered.
     var alignment: KeyboardVisualizerAlignment {
+        if self.placementMode == .custom {
+            switch self.stackAxis {
+            case .vertical:
+                return self.customHorizontalAlignment
+            case .horizontal:
+                return .center
+            }
+        }
+
         switch stackAxis {
         case .vertical:
             switch anchor.horizontal {
@@ -206,6 +216,14 @@ final class KeyboardVisualizerSettings: KeyboardVisualizerSettingsProtocol, HasS
     @Stored(.cgFloat(KeyboardVisualizerSettingsKeys.customPositionNormalizedY, default: 0.5, clamp: 0...1))
     var customPositionNormalizedY: CGFloat {
         didSet {
+            self.placementChangesSubject.send(())
+        }
+    }
+
+    @Stored(.enum(KeyboardVisualizerSettingsKeys.customHorizontalAlignment, default: .center))
+    var customHorizontalAlignment: KeyboardVisualizerAlignment {
+        didSet {
+            guard oldValue != self.customHorizontalAlignment else { return }
             self.placementChangesSubject.send(())
         }
     }

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettingsKeys.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettingsKeys.swift
@@ -30,6 +30,7 @@ enum KeyboardVisualizerSettingsKeys {
     static let placementMode = "keyboard_visualizer.placementMode"
     static let customPositionNormalizedX = "keyboard_visualizer.customPositionNormalizedX"
     static let customPositionNormalizedY = "keyboard_visualizer.customPositionNormalizedY"
+    static let customHorizontalAlignment = "keyboard_visualizer.customHorizontalAlignment"
     static let screenID     = "keyboard_visualizer.screenID"
     static let scale        = "keyboard_visualizer.scale"
     static let windowPadding = "keyboard_visualizer.windowPadding"

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerWindow.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerWindow.swift
@@ -125,25 +125,40 @@ final class KeyboardVisualizerWindow: NSWindow {
             }
         }
 
+        let layoutSize = NSSize(
+            width: max(contentSize.width, Size.bootstrapWindow.width),
+            height: max(contentSize.height, Size.bootstrapWindow.height)
+        )
+        let targetFrame = self.anchoredFrame(for: layoutSize)
+        let customVerticalAnchorX = self.customVerticalAnchorX(in: targetFrame)
+
         cursor = .zero
         for (view, size) in viewSizes {
             let origin: CGPoint
             switch stackAxis {
             case .horizontal:
-                origin = CGPoint(x: cursor.x, y: self.alignmentOffset(free: contentSize.height - size.height, alignment: alignment))
+                origin = CGPoint(x: cursor.x, y: self.alignmentOffset(free: layoutSize.height - size.height, alignment: alignment))
                 cursor.x += size.width + spacing
             case .vertical:
-                origin = CGPoint(x: self.alignmentOffset(free: contentSize.width - size.width, alignment: alignment), y: cursor.y)
+                origin = CGPoint(
+                    x: self.horizontalOriginX(
+                        for: size.width,
+                        layoutWidth: layoutSize.width,
+                        alignment: alignment,
+                        customAnchorX: customVerticalAnchorX
+                    ),
+                    y: cursor.y
+                )
                 cursor.y += size.height + spacing
             }
             view.frame = NSRect(origin: origin, size: size)
         }
 
-        self.rootView.frame = NSRect(origin: .zero, size: contentSize)
+        self.rootView.frame = NSRect(origin: .zero, size: layoutSize)
 
         // The window is pinned to a screen anchor: it grows inward from the anchored
         // edges as content is added/removed, rather than tracking its previous frame.
-        self.setFrame(self.anchoredFrame(for: contentSize), display: true, animate: false)
+        self.setFrame(targetFrame, display: true, animate: false)
     }
 
     /// Re-pins the window to its anchor using the current content size, without adding
@@ -199,7 +214,11 @@ final class KeyboardVisualizerWindow: NSWindow {
             y: area.minY + area.height * self.settings.customPositionNormalizedY
         )
         let origin = CGPoint(
-            x: center.x - size.width / 2,
+            x: Self.customHorizontalOriginX(
+                for: size.width,
+                anchoredAt: center.x,
+                alignment: self.settings.customHorizontalAlignment
+            ),
             y: center.y - size.height / 2
         )
         let clampedOrigin = CGPoint(
@@ -221,5 +240,61 @@ final class KeyboardVisualizerWindow: NSWindow {
         case .center:   return free / 2
         case .trailing: return free
         }
+    }
+
+    private func horizontalOriginX(
+        for width: CGFloat,
+        layoutWidth: CGFloat,
+        alignment: KeyboardVisualizerAlignment,
+        customAnchorX: CGFloat?
+    ) -> CGFloat {
+        if let customAnchorX {
+            return Self.customHorizontalOriginX(
+                for: width,
+                anchoredAt: customAnchorX,
+                alignment: self.settings.customHorizontalAlignment
+            )
+        }
+
+        return self.alignmentOffset(free: layoutWidth - width, alignment: alignment)
+    }
+
+    private func customVerticalAnchorX(in frame: NSRect) -> CGFloat? {
+        guard self.settings.placementMode == .custom, self.settings.stackAxis == .vertical else {
+            return nil
+        }
+        guard let area = self.resolvedVisibleFrame() else {
+            return nil
+        }
+
+        return Self.customHorizontalAnchorX(
+            in: frame,
+            visibleFrame: area,
+            normalizedX: self.settings.customPositionNormalizedX
+        )
+    }
+
+    static func customHorizontalOriginX(
+        for width: CGFloat,
+        anchoredAt x: CGFloat,
+        alignment: KeyboardVisualizerAlignment
+    ) -> CGFloat {
+        switch alignment {
+        case .leading:
+            return x
+        case .center:
+            return x - width / 2
+        case .trailing:
+            return x - width
+        }
+    }
+
+    static func customHorizontalAnchorX(
+        in windowFrame: NSRect,
+        visibleFrame: CGRect,
+        normalizedX: CGFloat
+    ) -> CGFloat {
+        let anchorX = visibleFrame.minX + visibleFrame.width * normalizedX
+        return anchorX - windowFrame.minX
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "displays.custom_position.set_subtitle" = "Wähle, wo die Einblendung auf dem ausgewählten Display erscheint.";
 "displays.custom_position.start_setting_button" = "Anordnen...";
 "displays.custom_position.stop_setting_button" = "Anwenden";
+"displays.custom_content_alignment_label" = "Inhaltsausrichtung";
+"displays.custom_content_alignment_subtitle" = "Wähle, wie sich die Einblendung horizontal von der benutzerdefinierten Position aus ausdehnt.";
 
 /* General settings pane */
 "general.appearance_section_title" = "App";

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "displays.custom_position.set_subtitle" = "Choose where the overlay appears on the selected display.";
 "displays.custom_position.start_setting_button" = "Arrange...";
 "displays.custom_position.stop_setting_button" = "Apply";
+"displays.custom_content_alignment_label" = "Content Alignment";
+"displays.custom_content_alignment_subtitle" = "Choose how the overlay expands horizontally from the custom position.";
 
 /* General settings pane */
 "general.appearance_section_title" = "App";

--- a/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "displays.custom_position.set_subtitle" = "Elige dónde aparece la superposición en la pantalla seleccionada.";
 "displays.custom_position.start_setting_button" = "Organizar...";
 "displays.custom_position.stop_setting_button" = "Aplicar";
+"displays.custom_content_alignment_label" = "Alineación del contenido";
+"displays.custom_content_alignment_subtitle" = "Elige cómo se expande horizontalmente la superposición desde la posición personalizada.";
 
 /* General settings pane */
 "general.appearance_section_title" = "Aplicación";

--- a/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "displays.custom_position.set_subtitle" = "Choisissez l’emplacement de la superposition sur l’écran sélectionné.";
 "displays.custom_position.start_setting_button" = "Organiser...";
 "displays.custom_position.stop_setting_button" = "Appliquer";
+"displays.custom_content_alignment_label" = "Alignement du contenu";
+"displays.custom_content_alignment_subtitle" = "Choisissez comment la superposition s’étend horizontalement à partir de la position personnalisée.";
 
 /* General settings pane */
 "general.appearance_section_title" = "Application";

--- a/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "displays.custom_position.set_subtitle" = "選択したディスプレイ上でオーバーレイを表示する位置を選択します。";
 "displays.custom_position.start_setting_button" = "配置...";
 "displays.custom_position.stop_setting_button" = "適用";
+"displays.custom_content_alignment_label" = "コンテンツの配置";
+"displays.custom_content_alignment_subtitle" = "カスタム位置を基準にオーバーレイが水平方向へどのように広がるかを選びます。";
 
 /* General settings pane */
 "general.appearance_section_title" = "アプリ";

--- a/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "displays.custom_position.set_subtitle" = "Виберіть, де накладка з’являтиметься на вибраному дисплеї.";
 "displays.custom_position.start_setting_button" = "Розмістити...";
 "displays.custom_position.stop_setting_button" = "Застосувати";
+"displays.custom_content_alignment_label" = "Вирівнювання вмісту";
+"displays.custom_content_alignment_subtitle" = "Виберіть, як накладка розширюється горизонтально від користувацької позиції.";
 
 /* General settings pane */
 "general.appearance_section_title" = "Програма";

--- a/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "displays.custom_position.set_subtitle" = "选择叠加层在所选显示器上的显示位置。";
 "displays.custom_position.start_setting_button" = "调整...";
 "displays.custom_position.stop_setting_button" = "应用";
+"displays.custom_content_alignment_label" = "内容对齐";
+"displays.custom_content_alignment_subtitle" = "选择叠加层如何从自定义位置向水平方向展开。";
 
 /* General settings pane */
 "general.appearance_section_title" = "应用";

--- a/Apps/Keyty/Tests/KeytyTests/Features/Settings/Displays/DisplaysSettingsPaneViewModelTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Settings/Displays/DisplaysSettingsPaneViewModelTests.swift
@@ -127,6 +127,18 @@ final class DisplaysSettingsPaneViewModelTests: XCTestCase {
         XCTAssertEqual(self.model.anchorSelection, .custom)
     }
 
+    func testCustomHorizontalAlignmentUpdatesSettings() {
+        self.model.customHorizontalAlignment = .trailing
+
+        XCTAssertEqual(self.keyboardVisualizerSettings.customHorizontalAlignment, .trailing)
+    }
+
+    func testPlacementChangesRefreshCustomHorizontalAlignment() {
+        self.keyboardVisualizerSettings.customHorizontalAlignment = .leading
+
+        XCTAssertEqual(self.model.customHorizontalAlignment, .leading)
+    }
+
     func testFinishingCustomPositionSettingStopsAndAppliesReturnedPlacement() {
         self.placementToReturn = KeyboardVisualizerPlacementWindowController.Placement(
             screenID: 2,
@@ -207,6 +219,56 @@ final class KeyboardVisualizerPlacementWindowControllerTests: XCTestCase {
 
         XCTAssertEqual(frame.midX, 300, accuracy: 0.0001)
         XCTAssertEqual(frame.midY, 650, accuracy: 0.0001)
+    }
+
+    func testFramePlacesLeadingAlignedHandleAtNormalizedPosition() {
+        let area = CGRect(x: 100, y: 200, width: 800, height: 600)
+        let size = CGSize(width: 120, height: 80)
+
+        let frame = KeyboardVisualizerPlacementWindowController.frame(
+            forNormalizedPosition: CGPoint(x: 0.25, y: 0.75),
+            in: area,
+            size: size,
+            horizontalAlignment: .leading
+        )
+
+        XCTAssertEqual(frame.minX, 300, accuracy: 0.0001)
+        XCTAssertEqual(frame.midY, 650, accuracy: 0.0001)
+    }
+
+    func testFramePlacesTrailingAlignedHandleAtNormalizedPosition() {
+        let area = CGRect(x: 100, y: 200, width: 800, height: 600)
+        let size = CGSize(width: 120, height: 80)
+
+        let frame = KeyboardVisualizerPlacementWindowController.frame(
+            forNormalizedPosition: CGPoint(x: 0.25, y: 0.75),
+            in: area,
+            size: size,
+            horizontalAlignment: .trailing
+        )
+
+        XCTAssertEqual(frame.maxX, 300, accuracy: 0.0001)
+        XCTAssertEqual(frame.midY, 650, accuracy: 0.0001)
+    }
+
+    func testAnchorXUsesAlignmentSpecificAnchorPoint() {
+        let frame = CGRect(x: 180, y: 200, width: 120, height: 80)
+
+        XCTAssertEqual(
+            KeyboardVisualizerPlacementWindowController.anchorX(in: frame, alignment: .leading),
+            180,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            KeyboardVisualizerPlacementWindowController.anchorX(in: frame, alignment: .center),
+            240,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            KeyboardVisualizerPlacementWindowController.anchorX(in: frame, alignment: .trailing),
+            300,
+            accuracy: 0.0001
+        )
     }
 
     func testFrameClampsHandleInsideVisibleFrame() {

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSettingsTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSettingsTests.swift
@@ -16,223 +16,266 @@ final class KeyboardVisualizerSettingsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        store = InMemoryKeyValueStore()
-        settings = KeyboardVisualizerSettings(store: store)
+        self.store = InMemoryKeyValueStore()
+        self.settings = KeyboardVisualizerSettings(store: self.store)
     }
 
     override func tearDown() {
-        settings = nil
-        store = nil
+        self.settings = nil
+        self.store = nil
         super.tearDown()
     }
 
     func testRegistersDefaults() {
-        settings.registerDefaults()
+        self.settings.registerDefaults()
 
-        XCTAssertEqual(store.bool(forKey: KeyboardVisualizerSettingsKeys.isEnabled), true)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.axis), KeyboardVisualizerStackAxis.vertical.storedValue)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.maxCount), KeyboardVisualizerSettingsKeys.defaultMaxCount)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDelay), 2.0, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDuration), 0.2, accuracy: 0.0001)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.theme), KeyboardVisualizerTheme.black.rawValue)
-        XCTAssertEqual(store.bool(forKey: KeyboardVisualizerSettingsKeys.usesCustomThemePalette), false)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.style), KeycapStyle.apple.rawValue)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.scale), 1.0, accuracy: 0.0001)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.placementMode), KeyboardVisualizerSettings.PlacementMode.anchored.rawValue)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedX), 0.5, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedY), 0.5, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.windowPadding), Double(Size.KeyboardVisualizer.windowPadding), accuracy: 0.0001)
-        XCTAssertEqual(store.bool(forKey: KeyboardVisualizerSettingsKeys.onlyShowModifiedKeystrokes), false)
-        XCTAssertEqual(store.bool(forKey: KeyboardVisualizerSettingsKeys.showSpecialKeys), true)
-        XCTAssertEqual(store.bool(forKey: KeyboardVisualizerSettingsKeys.showMediaKeyButtons), true)
-        XCTAssertEqual(store.bool(forKey: KeyboardVisualizerSettingsKeys.showMouseEvents), true)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.isEnabled), true)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.axis), KeyboardVisualizerStackAxis.vertical.storedValue)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.maxCount), KeyboardVisualizerSettingsKeys.defaultMaxCount)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDelay), 2.0, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDuration), 0.2, accuracy: 0.0001)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.theme), KeyboardVisualizerTheme.black.rawValue)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.usesCustomThemePalette), false)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.style), KeycapStyle.apple.rawValue)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.scale), 1.0, accuracy: 0.0001)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.placementMode), KeyboardVisualizerSettings.PlacementMode.anchored.rawValue)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedX), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedY), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.customHorizontalAlignment), KeyboardVisualizerAlignment.center.rawValue)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.windowPadding), Double(Size.KeyboardVisualizer.windowPadding), accuracy: 0.0001)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.onlyShowModifiedKeystrokes), false)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showSpecialKeys), true)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMediaKeyButtons), true)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMouseEvents), true)
     }
 
     func testSharedKeyboardVisualizerSettingsFallbackAndClamping() {
-        settings.maxCount = 0
-        XCTAssertEqual(settings.maxCount, 1)
+        self.settings.maxCount = 0
+        XCTAssertEqual(self.settings.maxCount, 1)
 
-        settings.stackAxis = .horizontal
-        XCTAssertEqual(settings.stackAxis, .horizontal)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.axis), KeyboardVisualizerStackAxis.horizontal.storedValue)
+        self.settings.stackAxis = .horizontal
+        XCTAssertEqual(self.settings.stackAxis, .horizontal)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.axis), KeyboardVisualizerStackAxis.horizontal.storedValue)
 
-        store.set(3, forKey: KeyboardVisualizerSettingsKeys.axis)
-        XCTAssertEqual(settings.stackAxis, .horizontal)
+        self.store.set(3, forKey: KeyboardVisualizerSettingsKeys.axis)
+        XCTAssertEqual(self.settings.stackAxis, .horizontal)
     }
 
     func testPersistsIsEnabled() {
-        settings.isEnabled = false
+        self.settings.isEnabled = false
 
-        XCTAssertFalse(settings.isEnabled)
-        XCTAssertFalse(store.bool(forKey: KeyboardVisualizerSettingsKeys.isEnabled))
+        XCTAssertFalse(self.settings.isEnabled)
+        XCTAssertFalse(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.isEnabled))
     }
 
     func testPublishesIsEnabledChanges() {
-        settings.registerDefaults()
+        self.settings.registerDefaults()
         var receivedValues: [Bool] = []
-        let cancellable = settings.isEnabledChanges.sink { value in
+        let cancellable = self.settings.isEnabledChanges.sink { value in
             receivedValues.append(value)
         }
 
-        settings.isEnabled = false
+        self.settings.isEnabled = false
 
         XCTAssertEqual(receivedValues, [false])
         cancellable.cancel()
     }
 
     func testDoesNotPublishIsEnabledWhenValueIsUnchanged() {
-        settings.registerDefaults()
+        self.settings.registerDefaults()
         var receivedValues: [Bool] = []
-        let cancellable = settings.isEnabledChanges.sink { value in
+        let cancellable = self.settings.isEnabledChanges.sink { value in
             receivedValues.append(value)
         }
 
-        settings.isEnabled = true
+        self.settings.isEnabled = true
 
         XCTAssertTrue(receivedValues.isEmpty)
         cancellable.cancel()
     }
 
     func testPersistsScale() {
-        settings.scale = 1.5
+        self.settings.scale = 1.5
 
-        XCTAssertEqual(settings.scale, 1.5, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.scale), 1.5, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.scale, 1.5, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.scale), 1.5, accuracy: 0.0001)
     }
 
     func testScaleClampsAndFallsBack() {
-        settings.scale = 5.0
-        XCTAssertEqual(settings.scale, 2.0, accuracy: 0.0001)
+        self.settings.scale = 5.0
+        XCTAssertEqual(self.settings.scale, 2.0, accuracy: 0.0001)
 
-        settings.scale = 0.1
-        XCTAssertEqual(settings.scale, 0.5, accuracy: 0.0001)
+        self.settings.scale = 0.1
+        XCTAssertEqual(self.settings.scale, 0.5, accuracy: 0.0001)
 
         // Unset (zero) falls back to the 100% default.
-        store.set(0.0, forKey: KeyboardVisualizerSettingsKeys.scale)
-        XCTAssertEqual(settings.scale, 1.0, accuracy: 0.0001)
+        self.store.set(0.0, forKey: KeyboardVisualizerSettingsKeys.scale)
+        XCTAssertEqual(self.settings.scale, 1.0, accuracy: 0.0001)
     }
 
     func testPersistsWindowPadding() {
-        settings.windowPadding = 24
+        self.settings.windowPadding = 24
 
-        XCTAssertEqual(settings.windowPadding, 24, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.windowPadding), 24, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.windowPadding, 24, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.windowPadding), 24, accuracy: 0.0001)
     }
 
     func testWindowPaddingClamps() {
-        settings.windowPadding = KeyboardVisualizerSettings.maxWindowPadding + 10
-        XCTAssertEqual(settings.windowPadding, KeyboardVisualizerSettings.maxWindowPadding, accuracy: 0.0001)
+        self.settings.windowPadding = KeyboardVisualizerSettings.maxWindowPadding + 10
+        XCTAssertEqual(self.settings.windowPadding, KeyboardVisualizerSettings.maxWindowPadding, accuracy: 0.0001)
 
-        settings.windowPadding = KeyboardVisualizerSettings.minWindowPadding - 10
-        XCTAssertEqual(settings.windowPadding, KeyboardVisualizerSettings.minWindowPadding, accuracy: 0.0001)
+        self.settings.windowPadding = KeyboardVisualizerSettings.minWindowPadding - 10
+        XCTAssertEqual(self.settings.windowPadding, KeyboardVisualizerSettings.minWindowPadding, accuracy: 0.0001)
     }
 
     func testPersistsPlacementMode() {
-        settings.placementMode = .custom
+        self.settings.placementMode = .custom
 
-        XCTAssertEqual(settings.placementMode, .custom)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.placementMode), KeyboardVisualizerSettings.PlacementMode.custom.rawValue)
+        XCTAssertEqual(self.settings.placementMode, .custom)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.placementMode), KeyboardVisualizerSettings.PlacementMode.custom.rawValue)
+    }
+
+    func testPersistsCustomHorizontalAlignment() {
+        self.settings.customHorizontalAlignment = .trailing
+
+        XCTAssertEqual(self.settings.customHorizontalAlignment, .trailing)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.customHorizontalAlignment), KeyboardVisualizerAlignment.trailing.rawValue)
+    }
+
+    func testCustomPlacementUsesCustomHorizontalAlignmentForVerticalStacks() {
+        self.settings.placementMode = .custom
+        self.settings.stackAxis = .vertical
+        self.settings.customHorizontalAlignment = .leading
+
+        XCTAssertEqual(self.settings.alignment, .leading)
+
+        self.settings.customHorizontalAlignment = .trailing
+
+        XCTAssertEqual(self.settings.alignment, .trailing)
+    }
+
+    func testCustomPlacementKeepsHorizontalStacksVerticallyCentered() {
+        self.settings.placementMode = .custom
+        self.settings.stackAxis = .horizontal
+        self.settings.customHorizontalAlignment = .trailing
+
+        XCTAssertEqual(self.settings.alignment, .center)
+    }
+
+    func testAnchoredPlacementStillDerivesAlignmentFromAnchor() {
+        self.settings.placementMode = .anchored
+        self.settings.stackAxis = .vertical
+        self.settings.anchor = .topLeft
+        self.settings.customHorizontalAlignment = .trailing
+
+        XCTAssertEqual(self.settings.alignment, .leading)
+
+        self.settings.stackAxis = .horizontal
+        self.settings.anchor = .topRight
+
+        XCTAssertEqual(self.settings.alignment, .trailing)
     }
 
     func testCustomPositionClamps() {
-        settings.customPositionNormalizedX = 1.5
-        settings.customPositionNormalizedY = -0.5
+        self.settings.customPositionNormalizedX = 1.5
+        self.settings.customPositionNormalizedY = -0.5
 
-        XCTAssertEqual(settings.customPositionNormalizedX, 1, accuracy: 0.0001)
-        XCTAssertEqual(settings.customPositionNormalizedY, 0, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedX), 1, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedY), 0, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.customPositionNormalizedX, 1, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.customPositionNormalizedY, 0, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedX), 1, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedY), 0, accuracy: 0.0001)
     }
 
     func testApplyCustomPlacementStoresDisplayAndClampedPosition() {
-        settings.applyCustomPlacement(
+        self.settings.applyCustomPlacement(
             screenID: 42,
             normalizedX: 1.5,
             normalizedY: -0.5
         )
 
-        XCTAssertEqual(settings.screenID, 42)
-        XCTAssertEqual(settings.customPositionNormalizedX, 1, accuracy: 0.0001)
-        XCTAssertEqual(settings.customPositionNormalizedY, 0, accuracy: 0.0001)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.screenID), 42)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedX), 1, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedY), 0, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.screenID, 42)
+        XCTAssertEqual(self.settings.customPositionNormalizedX, 1, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.customPositionNormalizedY, 0, accuracy: 0.0001)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.screenID), 42)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedX), 1, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.customPositionNormalizedY), 0, accuracy: 0.0001)
     }
 
     func testPublishesPlacementChangesForCustomPlacementSettings() {
         var receivedCount = 0
-        let cancellable = settings.placementChanges.sink { _ in
+        let cancellable = self.settings.placementChanges.sink { _ in
             receivedCount += 1
         }
 
-        settings.placementMode = .custom
-        settings.customPositionNormalizedX = 0.25
-        settings.customPositionNormalizedY = 0.75
+        self.settings.placementMode = .custom
+        self.settings.customPositionNormalizedX = 0.25
+        self.settings.customPositionNormalizedY = 0.75
+        self.settings.customHorizontalAlignment = .leading
 
         XCTAssertEqual(receivedCount, 3)
         cancellable.cancel()
     }
 
     func testPersistsSharedTimingSettings() {
-        settings.fadeDelay = 3.5
-        settings.fadeDuration = 0.45
+        self.settings.fadeDelay = 3.5
+        self.settings.fadeDuration = 0.45
 
-        XCTAssertEqual(settings.fadeDelay, 3.5, accuracy: 0.0001)
-        XCTAssertEqual(settings.fadeDuration, 0.45, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDelay), 3.5, accuracy: 0.0001)
-        XCTAssertEqual(store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDuration), 0.45, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.fadeDelay, 3.5, accuracy: 0.0001)
+        XCTAssertEqual(self.settings.fadeDuration, 0.45, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDelay), 3.5, accuracy: 0.0001)
+        XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.fadeDuration), 0.45, accuracy: 0.0001)
     }
 
     func testPersistsStyle() {
-        settings.style = .pbt
+        self.settings.style = .pbt
 
-        XCTAssertEqual(settings.style, .pbt)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.style), KeycapStyle.pbt.rawValue)
+        XCTAssertEqual(self.settings.style, .pbt)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.style), KeycapStyle.pbt.rawValue)
     }
 
     func testPersistsTheme() {
-        settings.theme = .rose
+        self.settings.theme = .rose
 
-        XCTAssertEqual(settings.theme, .rose)
-        XCTAssertEqual(store.integer(forKey: KeyboardVisualizerSettingsKeys.theme), KeyboardVisualizerTheme.rose.rawValue)
-        XCTAssertEqual(settings.themeTokens.textColor, KeyboardVisualizerTheme.rose.tokens.textColor)
+        XCTAssertEqual(self.settings.theme, .rose)
+        XCTAssertEqual(self.store.integer(forKey: KeyboardVisualizerSettingsKeys.theme), KeyboardVisualizerTheme.rose.rawValue)
+        XCTAssertEqual(self.settings.themeTokens.textColor, KeyboardVisualizerTheme.rose.tokens.textColor)
     }
 
     func testPersistsShowMediaKeyButtons() {
-        settings.showMediaKeyButtons = false
+        self.settings.showMediaKeyButtons = false
 
-        XCTAssertFalse(settings.showMediaKeyButtons)
-        XCTAssertFalse(store.bool(forKey: KeyboardVisualizerSettingsKeys.showMediaKeyButtons))
+        XCTAssertFalse(self.settings.showMediaKeyButtons)
+        XCTAssertFalse(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMediaKeyButtons))
     }
 
     func testPersistsOnlyShowModifiedKeystrokes() {
-        settings.onlyShowModifiedKeystrokes = true
+        self.settings.onlyShowModifiedKeystrokes = true
 
-        XCTAssertTrue(settings.onlyShowModifiedKeystrokes)
-        XCTAssertTrue(store.bool(forKey: KeyboardVisualizerSettingsKeys.onlyShowModifiedKeystrokes))
+        XCTAssertTrue(self.settings.onlyShowModifiedKeystrokes)
+        XCTAssertTrue(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.onlyShowModifiedKeystrokes))
     }
 
     func testPersistsShowSpecialKeys() {
-        settings.showSpecialKeys = false
+        self.settings.showSpecialKeys = false
 
-        XCTAssertFalse(settings.showSpecialKeys)
-        XCTAssertFalse(store.bool(forKey: KeyboardVisualizerSettingsKeys.showSpecialKeys))
+        XCTAssertFalse(self.settings.showSpecialKeys)
+        XCTAssertFalse(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showSpecialKeys))
     }
 
     func testPersistsShowMouseEvents() {
-        settings.showMouseEvents = false
+        self.settings.showMouseEvents = false
 
-        XCTAssertFalse(settings.showMouseEvents)
-        XCTAssertFalse(store.bool(forKey: KeyboardVisualizerSettingsKeys.showMouseEvents))
+        XCTAssertFalse(self.settings.showMouseEvents)
+        XCTAssertFalse(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMouseEvents))
     }
 
     func testAppearanceFollowsSelectedStyle() {
-        settings.theme = .citrus
-        settings.style = .apple
-        let appleAppearance = settings.appearance
+        self.settings.theme = .citrus
+        self.settings.style = .apple
+        let appleAppearance = self.settings.appearance
 
-        settings.style = .pbt
-        let pbtAppearance = settings.appearance
+        self.settings.style = .pbt
+        let pbtAppearance = self.settings.appearance
 
         XCTAssertEqual(appleAppearance.textColor, pbtAppearance.textColor)
         XCTAssertTrue(appleAppearance.apple != nil)
@@ -241,9 +284,9 @@ final class KeyboardVisualizerSettingsTests: XCTestCase {
     }
 
     func testThemeExposesSemanticTokens() {
-        settings.theme = .black
+        self.settings.theme = .black
 
-        XCTAssertEqual(settings.themeTokens.surfaceBaseColor, KeyboardVisualizerTheme.black.tokens.surfaceBaseColor)
-        XCTAssertEqual(settings.themeTokens.recessColor, KeyboardVisualizerTheme.black.tokens.recessColor)
+        XCTAssertEqual(self.settings.themeTokens.surfaceBaseColor, KeyboardVisualizerTheme.black.tokens.surfaceBaseColor)
+        XCTAssertEqual(self.settings.themeTokens.recessColor, KeyboardVisualizerTheme.black.tokens.recessColor)
     }
 }


### PR DESCRIPTION
## Summary

Add custom content alignment for custom keyboard visualizer placement and fix the related placement preview behavior.

- add a custom-only horizontal content alignment setting for vertical history stacks
- keep existing history rows pinned to the selected custom anchor when wider entries appear
- make the draggable placement preview use the same left/center/right anchor semantics as the real visualizer
- persist custom placement from the preview window's active anchor point instead of always using its center

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other:
  - `xcodebuild test -project Apps/Keyty/Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeyboardVisualizerWindowTests -only-testing:KeytyTests/KeyboardVisualizerSettingsTests`
  - `xcodebuild test -project Apps/Keyty/Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeyboardVisualizerPlacementWindowControllerTests -only-testing:KeytyTests/DisplaysSettingsPaneViewModelTests`

Run project commands from `Apps/Keyty`.

## UI Changes

<img width="905" height="648" alt="Screenshot 2026-08-08 at 18 16 28" src="https://github.com/user-attachments/assets/cc25c3dd-ad04-4519-bdeb-21ccae586f91" />

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Add custom content alignment for custom keyboard visualizer placement and fix preview positioning so the placement window matches the real overlay.
