### PR TITLE
docs: add repository security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest publicly released version of Keyty receives security updates.
+
+## Reporting a Vulnerability
+
+Functional defects with no security impact are regular application bugs and
+should be reported through GitHub Issues.
+
+Use GitHub's private vulnerability reporting form only for vulnerabilities that
+allow an attacker, through an untrusted process, a maliciously crafted update,
+or a tampered release artifact, to bypass Keyty's expected trust boundaries.
+This includes issues such as:
+
+- Executing attacker-controlled code or commands
+- Installing or accepting an untrusted update as trusted
+- Bypassing expected signing, notarization, or update integrity checks
+- Accessing permission-protected behavior in a way the user did not authorize
+- Causing unexpected disclosure of local input or other sensitive local data
+
+A report should include the affected Keyty version, macOS version, a
+description of the vulnerability and expected impact, and the steps required to
+reproduce it.
+
+Reports will be reviewed as soon as possible, but no specific response or
+resolution timeframe is guaranteed.


### PR DESCRIPTION
## Summary

Add a repository `SECURITY.md` that directs vulnerability reports to GitHub private vulnerability reporting and distinguishes security issues from regular application bugs.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: documentation-only change; tests not run

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
