### PR TITLE
fix(settings): restore theme legend separator

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
@@ -78,7 +78,9 @@ struct KeyboardSettingsPane: View {
                     ) {
                         self.legendColorControls
                     }
-                    
+
+                    Divider()
+
                     self.themePicker(
                         title: L10n.KeyboardVisualizer.regularThemeLabel,
                         subtitle: L10n.KeyboardVisualizer.regularThemeSubtitle,


### PR DESCRIPTION
## Summary

Restore the missing divider between the Legend Color control and the Regular keys theme picker in the custom keyboard theme section.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: not run for this small layout-only change

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| <img width="905" height="648" alt="Screenshot 2026-08-10 at 19 12 14" src="https://github.com/user-attachments/assets/812fe23b-0c3b-4911-bdcc-d2b413525994" /> | <img width="905" height="648" alt="Screenshot 2026-08-10 at 19 14 37" src="https://github.com/user-attachments/assets/751859cc-8ee5-457a-b8ff-dccd21827b8e" /> |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A
