### PR TITLE
fix(localization): use middle labels for vertical anchor positions

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "Mitte";
 "anchor.right" = "Rechts";
 "anchor.top" = "Oben";
-"anchor.vertical_center" = "Mitte";
+"anchor.vertical_center" = "Mittig";
 "anchor.bottom" = "Unten";
 
 /* Displays settings pane */

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "Center";
 "anchor.right" = "Right";
 "anchor.top" = "Top";
-"anchor.vertical_center" = "Center";
+"anchor.vertical_center" = "Middle";
 "anchor.bottom" = "Bottom";
 
 /* Displays settings pane */

--- a/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "Centro";
 "anchor.right" = "Derecha";
 "anchor.top" = "Arriba";
-"anchor.vertical_center" = "Centro";
+"anchor.vertical_center" = "Medio";
 "anchor.bottom" = "Abajo";
 
 /* Displays settings pane */

--- a/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "Centre";
 "anchor.right" = "Droite";
 "anchor.top" = "Haut";
-"anchor.vertical_center" = "Centre";
+"anchor.vertical_center" = "Milieu";
 "anchor.bottom" = "Bas";
 
 /* Displays settings pane */

--- a/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "中央";
 "anchor.right" = "右";
 "anchor.top" = "上";
-"anchor.vertical_center" = "中央";
+"anchor.vertical_center" = "中段";
 "anchor.bottom" = "下";
 
 /* Displays settings pane */

--- a/Apps/Keyty/Sources/Keyty/Resources/pl.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/pl.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "Środek";
 "anchor.right" = "Prawo";
 "anchor.top" = "Góra";
-"anchor.vertical_center" = "Środek";
+"anchor.vertical_center" = "Pośrodku";
 "anchor.bottom" = "Dół";
 
 /* Displays settings pane */

--- a/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "По центру";
 "anchor.right" = "Праворуч";
 "anchor.top" = "Вгорі";
-"anchor.vertical_center" = "По центру";
+"anchor.vertical_center" = "Посередині";
 "anchor.bottom" = "Внизу";
 
 /* Displays settings pane */

--- a/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "anchor.center" = "居中";
 "anchor.right" = "右侧";
 "anchor.top" = "顶部";
-"anchor.vertical_center" = "居中";
+"anchor.vertical_center" = "中间";
 "anchor.bottom" = "底部";
 
 /* Displays settings pane */


### PR DESCRIPTION
## Summary

- update anchor localization so vertical middle positions no longer reuse the horizontal center label
- align all shipped locales on a distinct vertical-middle term for keyboard anchor copy
- preserve the existing anchor model and UI composition while correcting the displayed text

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeyboardVisualizerAnchorTests`

Run project commands from `Apps/Keyty`.

## UI Changes

<img width="905" height="648" alt="Screenshot 2026-08-13 at 13 10 35" src="https://github.com/user-attachments/assets/df0f36d9-3232-43df-8a41-5125d2beef34" />

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Use middle-specific labels for vertical keyboard anchor positions in all localized settings UIs.
