### PR TITLE
refactor(display): render system keys as SF Symbols only

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Services/Display/InputEventSymbolMapper.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/InputEventSymbolMapper.swift
@@ -34,6 +34,7 @@ enum InputEventSymbolMapper {
         case .brightnessDown: return "sun.min.fill"
         case .missionControl: return "square.grid.2x2.fill"
         case .launchpad: return "square.grid.3x3.fill"
+        case .contextMenu: return "contextualmenu.and.cursorarrow"
         default: return nil
         }
     }

--- a/Apps/Keyty/Sources/Keyty/Services/Display/KeyboardSpecialKey+SystemKey.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/KeyboardSpecialKey+SystemKey.swift
@@ -23,28 +23,25 @@ extension KeyboardSpecialKey {
 }
 
 extension KeyboardSpecialKey.SystemKey {
-    /// Text rendered inside the keycap for this system key.
-    ///
-    /// System keys are represented by platform glyphs when available, and by a
-    /// compact readable name when no suitable glyph exists.
+    /// Short text name for this key; keycaps normally render an SF Symbol instead.
     var displayText: String {
         switch self {
         case .contextMenu:
-            return UnicodeToken.contextMenu.string
+            return "menu"
         case .brightnessUp:
-            return UnicodeToken.brightnessUp.string
+            return "brighter"
         case .brightnessDown:
-            return UnicodeToken.brightnessDown.string
+            return "dimmer"
         case .missionControl:
-            return UnicodeToken.missionControl.string
+            return "mission"
         case .launchpad:
-            return UnicodeToken.launchpad.string
+            return "launchpad"
         case .spotlight:
-            return UnicodeToken.spotlight.string
+            return "search"
         case .dictation:
-            return UnicodeToken.dictation.string
+            return "dictation"
         case .doNotDisturb:
-            return UnicodeToken.doNotDisturb.string
+            return "focus"
         }
     }
 

--- a/Apps/Keyty/Sources/Keyty/Services/Display/KeyboardSpecialKey.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/KeyboardSpecialKey.swift
@@ -60,9 +60,9 @@ extension KeyboardSpecialKey {
         case .keypadEnter:
             return UnicodeToken.keypadEnter.string
         case .space:
-            return UnicodeToken.visibleSpace.string + UnicodeToken.zeroWidthSpace.string
+            return UnicodeToken.visibleSpace.string
         case .help:
-            return UnicodeToken.questionMark.string + UnicodeToken.enclosingCircle.string
+            return "help"
         case .insert:
             return "ins"
         case .keypadClear:

--- a/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/UnicodeToken.swift
@@ -28,8 +28,6 @@ enum UnicodeToken {
     static let returnKey: Unicode.Scalar = "\u{21A9}"
     static let keypadEnter: Unicode.Scalar = "\u{2305}"
     
-    static let questionMark: Unicode.Scalar = "\u{003F}"
-    static let enclosingCircle: Unicode.Scalar = "\u{20DD}"
     static let home: Unicode.Scalar = "\u{2196}"
     static let end: Unicode.Scalar = "\u{2198}"
     static let pageUp: Unicode.Scalar = "\u{21DE}"
@@ -52,16 +50,9 @@ enum UnicodeToken {
     static let bulletOperator: Unicode.Scalar = "\u{2022}"
 
     static let visibleSpace: Unicode.Scalar = "\u{2423}"
-    static let zeroWidthSpace: Unicode.Scalar = "\u{200B}"
 
-    static let contextMenu: Unicode.Scalar = "\u{25A4}"
     static let brightnessDown: Unicode.Scalar = "\u{1F505}"
     static let brightnessUp: Unicode.Scalar = "\u{1F506}"
-    static let missionControl: Unicode.Scalar = "\u{1F5A5}"
-    static let spotlight: Unicode.Scalar = "\u{1F50D}"
-    static let dictation: Unicode.Scalar = "\u{1F3A4}"
-    static let launchpad: Unicode.Scalar = "\u{1F680}"
-    static let doNotDisturb: Unicode.Scalar = "\u{23FE}"
 
     static let speakerMuted: Unicode.Scalar = "\u{1F507}"
     static let speakerLow: Unicode.Scalar = "\u{1F509}"

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSpecialKeyFilteringTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSpecialKeyFilteringTests.swift
@@ -29,7 +29,7 @@ final class KeyboardVisualizerSpecialKeyFilteringTests: XCTestCase {
 
     func testClassifiesContextMenuKeyAsSystemKey() {
         XCTAssertEqual(KeyboardSpecialKeyResolver.specialKey(for: KeyboardKeyCode.contextMenu.rawValue), .system(.contextMenu))
-        XCTAssertEqual(KeyboardSpecialKey.SystemKey.contextMenu.displayText, UnicodeToken.contextMenu.string)
+        XCTAssertEqual(KeyboardSpecialKey.SystemKey.contextMenu.displayText, "menu")
     }
 
     func testResolverClassifiesInsertFunctionKeyAsSpecial() {

--- a/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/EventPipeline/EventTransformerKeystrokeTests.swift
@@ -105,22 +105,22 @@ extension EventTransformerKeystrokeTests {
 extension EventTransformerKeystrokeTests {
     func test_convertsFnF1ToBrightnessDecrease() {
         let keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessDown.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(self.transform(keystroke), UnicodeToken.brightnessDown.string)
+        XCTAssertEqual(self.transform(keystroke), "dimmer")
     }
 
     func test_convertsFnF2ToBrightnessIncrease() {
         let keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.brightnessUp.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(self.transform(keystroke), UnicodeToken.brightnessUp.string)
+        XCTAssertEqual(self.transform(keystroke), "brighter")
     }
 
     func test_convertsFnF3ToMissionControl() {
         let keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.missionControl.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(self.transform(keystroke), UnicodeToken.missionControl.string)
+        XCTAssertEqual(self.transform(keystroke), "mission")
     }
 
     func test_convertsFnF4ToLauncher() {
         let keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.launchpad.rawValue, modifiers: TestModifierFlags.function, characters: "", charactersIgnoringModifiers: "")
-        XCTAssertEqual(self.transform(keystroke), UnicodeToken.launchpad.string)
+        XCTAssertEqual(self.transform(keystroke), "launchpad")
     }
 }
 
@@ -224,7 +224,7 @@ extension EventTransformerKeystrokeTests {
     func test_helpFunctionKeyDisplaysHelpForHelpKeyCode() {
         let ch = TestKeyboardCharacters.functionKeyCharacter(NSHelpFunctionKey)
         let keystroke = TestKeystrokes.make(keyCode: KeyboardKeyCode.help.rawValue, modifiers: [], characters: ch, charactersIgnoringModifiers: ch)
-        XCTAssertEqual(self.transform(keystroke), UnicodeToken.questionMark.string + UnicodeToken.enclosingCircle.string)
+        XCTAssertEqual(self.transform(keystroke), "help")
     }
 
     func test_helpKeyCodeWithoutSemanticCharactersDefaultsToInsert() {


### PR DESCRIPTION
## Summary

Render system keys with SF Symbols when available and fall back to short text labels instead of legacy Unicode glyphs.

This keeps system-key keycaps consistent with the symbol mapper, adds an SF Symbol for the context-menu key, and removes unused Unicode token constants that are no longer part of the display path.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [ ] Other:

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Render system keyboard keys with SF Symbols where available, with shorter text fallbacks for keys that do not have a matching symbol.
