### PR TITLE
chore(github): remove colons from issue template titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report a reproducible problem with Keyty.
-title: "[Bug]: "
+title: "[Bug] "
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an improvement or new capability for Keyty.
-title: "[Feature]: "
+title: "[Feature] "
 labels:
   - enhancement
 body:


### PR DESCRIPTION
## Summary

- Remove the colon from the default `[Bug]` and `[Feature]` issue title prefixes.
- Keep new issue titles cleaner while preserving the existing label-style prefixes.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: not needed for GitHub issue template text changes

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A
