### PR TITLE
fix(display): always uppercase layout-translated key legends

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Services/Display/EventLegendResolver.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Display/EventLegendResolver.swift
@@ -90,10 +90,10 @@ private extension EventLegendResolver {
 
 // MARK: - Layout Translation
 private extension EventLegendResolver {
-    // The legend printed on the physical key, cased for a modified chord.
+    // The legend printed on the physical key, which is uppercase on a real
+    // keyboard whether or not a modifier is held.
     func translatedKey(_ keystroke: StandardKeyEvent) -> String {
-        let translated = self.uchrData.translatedKeyCode(keystroke.keyCode)
-        return keystroke.isModified ? Self.legendCased(translated) : translated
+        Self.legendCased(self.uchrData.translatedKeyCode(keystroke.keyCode))
     }
 
     // Uppercases a legend only when the result keeps its length.

--- a/Apps/Keyty/Tests/KeytyTests/Services/Display/EventLegendResolverStandardKeyEventTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Services/Display/EventLegendResolverStandardKeyEventTests.swift
@@ -51,12 +51,13 @@ extension EventLegendResolverStandardKeyEventTests {
         }
     }
 
-    /// A digit has no distinct uppercase form, so only letters show the casing rule.
-    func testLetterTextIsUppercasedOnlyWhenModified() {
-        for (modifiers, kinds, name) in Self.allModifierCombinations {
+    /// A legend is the label printed on the key, which is uppercase whether or
+    /// not a modifier is held.
+    func testLetterTextIsAlwaysUppercased() {
+        for (modifiers, _, name) in Self.allModifierCombinations {
             let legend = self.legend(.stub(keyCode: .a, modifiers: modifiers))
 
-            XCTAssertEqual(legend.text, kinds.isEmpty ? "a" : "A", "for \(name)")
+            XCTAssertEqual(legend.text, "A", "for \(name)")
             XCTAssertEqual(legend.kind, .text, "for \(name)")
         }
     }


### PR DESCRIPTION
## Summary

Always uppercase layout-translated standard key legends so displayed key labels match the legends printed on physical keyboards, even when no modifier is held.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Uppercase keyboard legends consistently for translated standard keys.
