### PR TITLE
feat(release): dispatch website appcast sync after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,3 +167,38 @@ jobs:
       - name: Skip Homebrew tap update dispatch
         if: ${{ env.HOMEBREW_TAP_DISPATCH_TOKEN == '' }}
         run: echo "::notice::Skipping Homebrew tap update dispatch because HOMEBREW_TAP_DISPATCH_TOKEN is not configured."
+
+  sync-appcast-website:
+    if: ${{ !endsWith(github.ref_name, '-test') }}
+    runs-on: ubuntu-latest
+    needs: release
+    env:
+      KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN: ${{ secrets.KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN }}
+      KEYTY_APPCAST_WEBSITE_REPOSITORY: ${{ vars.KEYTY_APPCAST_WEBSITE_REPOSITORY || 'esphynox/keyty.app' }}
+
+    steps:
+      - name: Dispatch website appcast sync
+        if: ${{ env.KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ env.KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh api "repos/${KEYTY_APPCAST_WEBSITE_REPOSITORY}/dispatches" \
+            --method POST \
+            --input - <<EOF
+          {
+            "event_type": "keyty_appcast_release",
+            "client_payload": {
+              "version": "${GITHUB_REF_NAME#v}",
+              "tag": "${GITHUB_REF_NAME}",
+              "source_repo": "${GITHUB_REPOSITORY}",
+              "run_id": "${GITHUB_RUN_ID}"
+            }
+          }
+          EOF
+
+      - name: Skip website appcast sync dispatch
+        if: ${{ env.KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN == '' }}
+        run: echo "::notice::Skipping website appcast sync because KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN is not configured."


### PR DESCRIPTION
## Summary

Add a post-release workflow job that dispatches the website appcast sync automation in `esphynox/keyty.app` after the Keyty release job succeeds. This lets the app release trigger the existing PR-based appcast update flow in the website repo without coupling site changes into this repository.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination platform=macOS`
- [x] Other: Reviewed workflow structure and payload against the website repo release-sync-appcast workflow contract.

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A