### PR TITLE
fix(tests): update about contributors expectations

### DIFF
--- a/Apps/Keyty/Tests/KeytyTests/Features/About/AboutWindowViewModelTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/About/AboutWindowViewModelTests.swift
@@ -22,6 +22,7 @@ final class AboutWindowViewModelTests: XCTestCase {
                 "Yullia Babichuk",
                 "Oleksii Petruk",
                 "Serhii Butenko",
+                "James Haskin",
             ]
         )
     }
@@ -33,6 +34,6 @@ final class AboutWindowViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.selectedSections.first?.title, "Contributors")
         XCTAssertEqual(viewModel.selectedSections.first?.subtitle, "People who helped make Keyty better.")
-        XCTAssertEqual(viewModel.selectedSections.first?.listItems.count, 4)
+        XCTAssertEqual(viewModel.selectedSections.first?.listItems.count, 5)
     }
 }


### PR DESCRIPTION
## Summary

Update `AboutWindowViewModelTests` to match the contributor list that is already present on `main`.

The merged change from PR #111 added `James Haskin` to `AboutWindowViewModel.contributors`, but the tests still expected four contributors. This PR fixes the stale expectations so CI reflects the current app behavior.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/AboutWindowViewModelTests`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A
