### PR TITLE
fix(keyboard): show standalone special keys with combo-only filter

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
@@ -136,12 +136,13 @@ final class KeyboardVisualizer {
             return
         }
 
-        if self.visualizerSettings.onlyShowModifiedKeystrokes && !keystroke.isModified {
+        let isSpecialKey = KeyboardSpecialKeyResolver.isSpecial(keystroke)
+
+        if !self.visualizerSettings.showSpecialKeys, isSpecialKey {
             return
         }
 
-        if !self.visualizerSettings.showSpecialKeys,
-           KeyboardSpecialKeyResolver.isSpecial(keystroke) {
+        if self.visualizerSettings.onlyShowModifiedKeystrokes && !keystroke.isModified && !isSpecialKey {
             return
         }
 

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
@@ -59,4 +59,37 @@ final class KeyboardVisualizerTests: XCTestCase {
         XCTAssertEqual(self.visualizer.visibleGroupCount, 0)
         XCTAssertTrue(self.settings.isEnabled)
     }
+
+    func testOnlyShowModifiedKeystrokesStillShowsStandaloneSpecialKeys() {
+        self.settings.onlyShowModifiedKeystrokes = true
+        self.settings.showSpecialKeys = true
+        self.visualizer.isPresentationActive = true
+
+        self.visualizer.display(.keystroke(.stub(keyCode: .escape)))
+
+        XCTAssertEqual(self.visualizer.visibleGroupCount, 1)
+    }
+
+    func testOnlyShowModifiedKeystrokesStillHidesStandaloneRegularKeys() {
+        self.settings.onlyShowModifiedKeystrokes = true
+        self.visualizer.isPresentationActive = true
+
+        self.visualizer.display(.keystroke(.stub(
+            keyCode: .a,
+            characters: "a",
+            charactersIgnoringModifiers: "a"
+        )))
+
+        XCTAssertEqual(self.visualizer.visibleGroupCount, 0)
+    }
+
+    func testSpecialKeysToggleStillHidesStandaloneSpecialKeysWhenDisabled() {
+        self.settings.onlyShowModifiedKeystrokes = true
+        self.settings.showSpecialKeys = false
+        self.visualizer.isPresentationActive = true
+
+        self.visualizer.display(.keystroke(.stub(keyCode: .escape)))
+
+        XCTAssertEqual(self.visualizer.visibleGroupCount, 0)
+    }
 }


### PR DESCRIPTION
## Summary

- keep standalone special keys visible when `Show key combinations only` is enabled and `Special keys` is on
- continue hiding unmodified regular keys under the combo-only filter
- add regression coverage for special-key and regular-key filtering behavior

Addresses #88 and #89

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild test -project Apps/Keyty/Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeyboardVisualizerTests -only-testing:KeytyTests/KeyboardVisualizerSpecialKeyFilteringTests`

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Standalone special keys like Escape and function keys remain visible when `Show key combinations only` is enabled and `Special keys` is on.
