### PR TITLE
feat(displays): clarify custom alignment picker labels

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Displays/DisplaysSettingsPane.swift
@@ -115,8 +115,8 @@ private extension DisplaysSettingsPane {
                 subtitle: L10n.Displays.customHorizontalAlignmentSubtitle
             ) {
                 Picker("", selection: self.$model.customHorizontalAlignment) {
-                    ForEach(KeyboardVisualizerAlignment.allCases, id: \.rawValue) { alignment in
-                        Text(alignment.horizontalLabel).tag(alignment)
+                    ForEach(KeyboardVisualizerAlignment.horizontalOptions, id: \.rawValue) { alignment in
+                        Text(alignment.horizontalPickerTitle).tag(alignment)
                     }
                 }
                 .labelsHidden()
@@ -131,8 +131,8 @@ private extension DisplaysSettingsPane {
                 subtitle: L10n.Displays.customVerticalAlignmentSubtitle
             ) {
                 Picker("", selection: self.$model.customVerticalAlignment) {
-                    ForEach(KeyboardVisualizerAlignment.allCases, id: \.rawValue) { alignment in
-                        Text(alignment.verticalLabel).tag(alignment)
+                    ForEach(KeyboardVisualizerAlignment.verticalOptions, id: \.rawValue) { alignment in
+                        Text(alignment.verticalPickerTitle).tag(alignment)
                     }
                 }
                 .labelsHidden()

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerAlignment.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerAlignment.swift
@@ -16,25 +16,58 @@ enum KeyboardVisualizerAlignment: Int, CaseIterable {
     /// Pinned to the cross-axis end (right for a vertical stack, top for a horizontal stack).
     case trailing = 2
 
-    var horizontalLabel: String {
+    static let horizontalOptions: [KeyboardVisualizerAlignment] = [.leading, .center, .trailing]
+    static let verticalOptions: [KeyboardVisualizerAlignment] = [.trailing, .center, .leading]
+
+    var horizontalPickerIcon: String {
         switch self {
         case .leading:
-            L10n.Anchor.left
+            "⇥"
         case .center:
-            L10n.Anchor.center
+            "◆"
         case .trailing:
-            L10n.Anchor.right
+            "⇤"
         }
     }
 
-    var verticalLabel: String {
+    var horizontalPickerLabel: String {
         switch self {
         case .leading:
-            L10n.Anchor.bottom
+            L10n.Displays.horizontalAlignmentLeftToRight
         case .center:
-            L10n.Anchor.verticalCenter
+            L10n.Displays.horizontalAlignmentCenterOut
         case .trailing:
-            L10n.Anchor.top
+            L10n.Displays.horizontalAlignmentRightToLeft
         }
+    }
+
+    var verticalPickerIcon: String {
+        switch self {
+        case .leading:
+            "↑"
+        case .center:
+            "◆"
+        case .trailing:
+            "↓"
+        }
+    }
+
+    var verticalPickerLabel: String {
+        switch self {
+        case .leading:
+            L10n.Displays.verticalAlignmentBottomUp
+        case .center:
+            L10n.Displays.verticalAlignmentMiddleOut
+        case .trailing:
+            L10n.Displays.verticalAlignmentTopDown
+        }
+    }
+
+    var horizontalPickerTitle: String {
+        "\(self.horizontalPickerIcon) \(self.horizontalPickerLabel)"
+    }
+
+    var verticalPickerTitle: String {
+        "\(self.verticalPickerIcon) \(self.verticalPickerLabel)"
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "Wähle, wie sich die Einblendung horizontal von der benutzerdefinierten Position aus ausdehnt.";
 "displays.custom_vertical_alignment_label" = "Vertikale Ausrichtung";
 "displays.custom_vertical_alignment_subtitle" = "Wähle, wie sich die Einblendung vertikal von der benutzerdefinierten Position aus ausdehnt.";
+"displays.horizontal_alignment_left_to_right" = "Von links nach rechts";
+"displays.horizontal_alignment_center_out" = "Aus der Mitte";
+"displays.horizontal_alignment_right_to_left" = "Von rechts nach links";
+"displays.vertical_alignment_top_down" = "Von oben nach unten";
+"displays.vertical_alignment_middle_out" = "Aus der Mitte";
+"displays.vertical_alignment_bottom_up" = "Von unten nach oben";
 
 /* General settings pane */
 "general.appearance_section_title" = "App";

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "Choose how the overlay expands horizontally from the custom position.";
 "displays.custom_vertical_alignment_label" = "Vertical Alignment";
 "displays.custom_vertical_alignment_subtitle" = "Choose how the overlay expands vertically from the custom position.";
+"displays.horizontal_alignment_left_to_right" = "Left to Right";
+"displays.horizontal_alignment_center_out" = "Center Out";
+"displays.horizontal_alignment_right_to_left" = "Right to Left";
+"displays.vertical_alignment_top_down" = "Top Down";
+"displays.vertical_alignment_middle_out" = "Middle Out";
+"displays.vertical_alignment_bottom_up" = "Bottom Up";
 
 /* General settings pane */
 "general.appearance_section_title" = "App";

--- a/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "Elige cómo se expande horizontalmente la superposición desde la posición personalizada.";
 "displays.custom_vertical_alignment_label" = "Alineación vertical";
 "displays.custom_vertical_alignment_subtitle" = "Elige cómo se expande verticalmente la superposición desde la posición personalizada.";
+"displays.horizontal_alignment_left_to_right" = "De izquierda a derecha";
+"displays.horizontal_alignment_center_out" = "Desde el centro";
+"displays.horizontal_alignment_right_to_left" = "De derecha a izquierda";
+"displays.vertical_alignment_top_down" = "De arriba abajo";
+"displays.vertical_alignment_middle_out" = "Desde el centro";
+"displays.vertical_alignment_bottom_up" = "De abajo arriba";
 
 /* General settings pane */
 "general.appearance_section_title" = "Aplicación";

--- a/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "Choisissez comment la superposition s’étend horizontalement à partir de la position personnalisée.";
 "displays.custom_vertical_alignment_label" = "Alignement vertical";
 "displays.custom_vertical_alignment_subtitle" = "Choisissez comment la superposition s’étend verticalement à partir de la position personnalisée.";
+"displays.horizontal_alignment_left_to_right" = "De gauche à droite";
+"displays.horizontal_alignment_center_out" = "Depuis le centre";
+"displays.horizontal_alignment_right_to_left" = "De droite à gauche";
+"displays.vertical_alignment_top_down" = "De haut en bas";
+"displays.vertical_alignment_middle_out" = "Depuis le milieu";
+"displays.vertical_alignment_bottom_up" = "De bas en haut";
 
 /* General settings pane */
 "general.appearance_section_title" = "Application";

--- a/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "カスタム位置を基準にオーバーレイが水平方向へどのように広がるかを選びます。";
 "displays.custom_vertical_alignment_label" = "垂直方向の配置";
 "displays.custom_vertical_alignment_subtitle" = "カスタム位置を基準にオーバーレイが垂直方向へどのように広がるかを選びます。";
+"displays.horizontal_alignment_left_to_right" = "左から右へ";
+"displays.horizontal_alignment_center_out" = "中央から外へ";
+"displays.horizontal_alignment_right_to_left" = "右から左へ";
+"displays.vertical_alignment_top_down" = "上から下へ";
+"displays.vertical_alignment_middle_out" = "中央から外へ";
+"displays.vertical_alignment_bottom_up" = "下から上へ";
 
 /* General settings pane */
 "general.appearance_section_title" = "アプリ";

--- a/Apps/Keyty/Sources/Keyty/Resources/nl.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/nl.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "Kies hoe de overlay zich horizontaal uitbreidt vanaf de aangepaste positie.";
 "displays.custom_vertical_alignment_label" = "Verticale uitlijning";
 "displays.custom_vertical_alignment_subtitle" = "Kies hoe de overlay zich verticaal uitbreidt vanaf de aangepaste positie.";
+"displays.horizontal_alignment_left_to_right" = "Van links naar rechts";
+"displays.horizontal_alignment_center_out" = "Vanuit het midden";
+"displays.horizontal_alignment_right_to_left" = "Van rechts naar links";
+"displays.vertical_alignment_top_down" = "Van boven naar beneden";
+"displays.vertical_alignment_middle_out" = "Vanuit het midden";
+"displays.vertical_alignment_bottom_up" = "Van beneden naar boven";
 
 /* General settings pane */
 "general.appearance_section_title" = "App";

--- a/Apps/Keyty/Sources/Keyty/Resources/pl.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/pl.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "Wybierz, jak nakładka ma rozszerzać się poziomo od własnej pozycji.";
 "displays.custom_vertical_alignment_label" = "Wyrównanie w pionie";
 "displays.custom_vertical_alignment_subtitle" = "Wybierz, jak nakładka ma rozszerzać się pionowo od własnej pozycji.";
+"displays.horizontal_alignment_left_to_right" = "Od lewej do prawej";
+"displays.horizontal_alignment_center_out" = "Od środka";
+"displays.horizontal_alignment_right_to_left" = "Od prawej do lewej";
+"displays.vertical_alignment_top_down" = "Z góry na dół";
+"displays.vertical_alignment_middle_out" = "Od środka";
+"displays.vertical_alignment_bottom_up" = "Z dołu do góry";
 
 /* General settings pane */
 "general.appearance_section_title" = "Aplikacja";

--- a/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "Виберіть, як накладка розширюється горизонтально від користувацької позиції.";
 "displays.custom_vertical_alignment_label" = "Вертикальне вирівнювання";
 "displays.custom_vertical_alignment_subtitle" = "Виберіть, як накладка розширюється вертикально від користувацької позиції.";
+"displays.horizontal_alignment_left_to_right" = "Зліва направо";
+"displays.horizontal_alignment_center_out" = "Від центру";
+"displays.horizontal_alignment_right_to_left" = "Справа наліво";
+"displays.vertical_alignment_top_down" = "Згори вниз";
+"displays.vertical_alignment_middle_out" = "Від центру";
+"displays.vertical_alignment_bottom_up" = "Знизу вгору";
 
 /* General settings pane */
 "general.appearance_section_title" = "Програма";

--- a/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
@@ -54,6 +54,12 @@
 "displays.custom_horizontal_alignment_subtitle" = "选择叠加层如何从自定义位置向水平方向展开。";
 "displays.custom_vertical_alignment_label" = "垂直对齐";
 "displays.custom_vertical_alignment_subtitle" = "选择叠加层如何从自定义位置向垂直方向展开。";
+"displays.horizontal_alignment_left_to_right" = "从左到右";
+"displays.horizontal_alignment_center_out" = "从中间向外";
+"displays.horizontal_alignment_right_to_left" = "从右到左";
+"displays.vertical_alignment_top_down" = "从上到下";
+"displays.vertical_alignment_middle_out" = "从中间向外";
+"displays.vertical_alignment_bottom_up" = "从下到上";
 
 /* General settings pane */
 "general.appearance_section_title" = "应用";

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/KeyboardVisualizerAlignmentPlacementTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/KeyboardVisualizerAlignmentPlacementTests.swift
@@ -13,6 +13,14 @@ final class KeyboardVisualizerAlignmentPlacementTests: XCTestCase {
     private let area = CGRect(x: 100, y: 200, width: 800, height: 600)
     private let size = CGSize(width: 120, height: 80)
 
+    func testHorizontalOptionsFollowReadingDirection() {
+        XCTAssertEqual(KeyboardVisualizerAlignment.horizontalOptions, [.leading, .center, .trailing])
+    }
+
+    func testVerticalOptionsFollowTopToBottomOrder() {
+        XCTAssertEqual(KeyboardVisualizerAlignment.verticalOptions, [.trailing, .center, .leading])
+    }
+
     func testFrameCentersContentOnNormalizedPosition() {
         let frame = KeyboardVisualizerAlignment.frame(
             for: self.size,


### PR DESCRIPTION
## Summary

Clarifies the custom display alignment pickers by separating horizontal and vertical option ordering and switching the labels to directional wording.

This updates the settings UI so horizontal options read left-to-right, vertical options read top-to-bottom, and the symbol glyphs are composed in code rather than embedded in localized strings.

Closes #116.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeyboardVisualizerAlignmentPlacementTests`

Run project commands from `Apps/Keyty`.

## UI Changes
<img width="905" height="648" alt="new-alignment-labels" src="https://github.com/user-attachments/assets/8ab28945-7ba1-4365-af75-315968322aaf" />

## Documentation

- [x] No docs needed

## Release Notes

Custom display alignment settings now use clearer directional labels and a more intuitive option order.
