### PR TITLE
fix(keyboard): add per-style repeat badge insets

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerGroupView.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerGroupView.swift
@@ -175,6 +175,19 @@ private extension KeyboardVisualizerGroupView {
             return AppleKeycapMetrics.itemSpacing
         }
     }
+
+    private var repeatBadgeInset: CGPoint {
+        switch self.settings.style {
+        case .minimal:
+            return MinimalKeycapMetrics.repeatBadgeInset
+        case .retro:
+            return RetroKeycapMetrics.repeatBadgeInset
+        case .apple:
+            return AppleKeycapMetrics.repeatBadgeInset
+        case .pbt:
+            return PBTKeycapMetrics.repeatBadgeInset
+        }
+    }
 }
 
 // MARK: - Drawing
@@ -214,9 +227,10 @@ private extension KeyboardVisualizerGroupView {
         let labelSize = badgeText.size(withAttributes: attributes)
         let badgeHeight = max(26, labelSize.height + 8)
         let badgeWidth = max(badgeHeight, labelSize.width + 14)
+        let inset = self.repeatBadgeInset
         let badgeRect = NSRect(
-            x: self.baseSize.width - badgeWidth - 6,
-            y: self.baseSize.height - badgeHeight - 6,
+            x: self.baseSize.width - badgeWidth - inset.x,
+            y: self.baseSize.height - badgeHeight - inset.y,
             width: badgeWidth,
             height: badgeHeight
         )

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Renderers/KeycapMetrics.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/Renderers/KeycapMetrics.swift
@@ -38,6 +38,7 @@ enum AppleKeycapMetrics {
     static let minWidth: CGFloat = 74
     static let itemSpacing: CGFloat = 6
     static let groupPadding = NSEdgeInsets(top: 10, left: 10, bottom: 18, right: 10)
+    static let repeatBadgeInset = CGPoint(x: 6, y: 6)
 }
 
 enum MinimalKeycapMetrics {
@@ -46,6 +47,7 @@ enum MinimalKeycapMetrics {
     static let horizontalPadding: CGFloat = 4
     static let itemSpacing: CGFloat = -8
     static let groupPadding = NSEdgeInsets(top: 8, left: 14, bottom: 8, right: 14)
+    static let repeatBadgeInset = CGPoint(x: 0, y: 0)
     static let labelFont = NSFont.systemFont(ofSize: 26, weight: .medium)
     static let symbolFont = NSFont.systemFont(ofSize: 36, weight: .medium)
     static let imageMaxHeight: CGFloat = 36
@@ -64,6 +66,7 @@ enum RetroKeycapMetrics {
     static let horizontalPadding: CGFloat = 24
     static let itemSpacing: CGFloat = 10
     static let groupPadding = NSEdgeInsets(top: 12, left: 12, bottom: 16, right: 12)
+    static let repeatBadgeInset = CGPoint(x: 6, y: 6)
     static let pressedTravel: CGFloat = 3
 }
 
@@ -77,6 +80,7 @@ enum PBTKeycapMetrics {
     static let pressedTravel: CGFloat = 2.5
     static let bodyInset: CGFloat = 2
     static let groupPadding = NSEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
+    static let repeatBadgeInset = CGPoint(x: 6, y: 6)
 }
 
 extension KeycapStyle {


### PR DESCRIPTION
## Summary

Add per-style repeat badge inset metrics for keyboard visualizer groups while keeping the current visual offsets unchanged.

This moves the badge offset out of the hardcoded draw path so style-specific badge positioning can be tuned cleanly later.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [ ] Other:

Run project commands from `Apps/Keyty`.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write `N/A` if there are none.

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Refactor repeat badge positioning to use per-style inset metrics for future tuning.