### PR TITLE
docs(releasing): document automatic appcast website sync

### DIFF
--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -12,7 +12,7 @@ let appSettings: SettingsDictionary = [
     "ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS": "YES",
     "CLANG_ENABLE_OBJC_WEAK": "YES",
     "CODE_SIGN_ENTITLEMENTS": "Sources/Keyty/Resources/Keyty.entitlements",
-    "CURRENT_PROJECT_VERSION": "130",
+    "CURRENT_PROJECT_VERSION": "140",
     "DEAD_CODE_STRIPPING": "YES",
     "ENABLE_HARDENED_RUNTIME": "YES",
     "FRAMEWORK_SEARCH_PATHS": [
@@ -28,7 +28,7 @@ let appSettings: SettingsDictionary = [
         "$(inherited)",
         "@executable_path/../Frameworks",
     ],
-    "MARKETING_VERSION": "1.3.0",
+    "MARKETING_VERSION": "1.4.0",
     "PRODUCT_BUNDLE_IDENTIFIER": "app.keyty.Keyty",
     "PRODUCT_NAME": "Keyty",
     "PROVISIONING_PROFILE_SPECIFIER": "",

--- a/Docs/RELEASING.md
+++ b/Docs/RELEASING.md
@@ -52,6 +52,7 @@ Configure these repository secrets before running the workflow:
 | `NOTARY_ISSUER` | App Store Connect issuer ID |
 | `SPARKLE_ED_KEY_BASE64` | Base64-encoded Sparkle EdDSA private key |
 | `HOMEBREW_TAP_DISPATCH_TOKEN` | Optional token with permission to dispatch workflows in `keytyapp/homebrew-tap`; when present, the release workflow triggers the tap repo's cask-update automation after publishing `v*` release assets |
+| `KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN` | Optional token with permission to dispatch workflows in the website repo; when present, the release workflow triggers the website repo's appcast sync automation after publishing `v*` release assets |
 
 Optionally configure these repository variables:
 
@@ -59,11 +60,13 @@ Optionally configure these repository variables:
 |---|---|
 | `APPCAST_DOWNLOAD_PREFIX` | Sparkle enclosure URL prefix. By default, the release lane uses the current GitHub release asset URL, such as `https://github.com/keytyapp/Keyty/releases/download/v0.8.0/` |
 | `KEYTY_RELEASE_TEAM_ID` | Developer ID team, default `NEVA4MAZBL` |
+| `KEYTY_APPCAST_WEBSITE_REPOSITORY` | Website repository that receives the appcast sync dispatch, default `esphynox/keyty.app` |
 
 The release workflow uploads generated appcast artifacts as an Actions artifact.
-Publish `appcast.xml` from that artifact through the Vercel-hosted site so
-Sparkle reads `https://keyty.app/appcast.xml`. Update archives are hosted as
-GitHub release assets by default.
+When `KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN` is configured, the same workflow
+also dispatches `keyty_appcast_release` to the website repository so it can
+publish `appcast.xml` to `https://keyty.app/appcast.xml`. Update archives are
+hosted as GitHub release assets by default.
 
 When `HOMEBREW_TAP_DISPATCH_TOKEN` is configured, the same workflow also
 dispatches `keyty_release_published` to `keytyapp/homebrew-tap` with the new
@@ -131,7 +134,10 @@ git push --tags
 
 5. Let the GitHub `Release` workflow build, sign, notarize, staple, and create the GitHub release.
 6. Confirm the GitHub release contains both the zipped app and the DMG.
-7. Download the `appcast-artifacts` workflow artifact and publish `appcast.xml` through the Vercel-hosted site.
+7. Confirm the website appcast sync automation completed and published the new `appcast.xml`.
+   If `KEYTY_APPCAST_WEBSITE_DISPATCH_TOKEN` is not configured or the website
+   automation fails, download the `appcast-artifacts` workflow artifact and
+   publish `appcast.xml` through the Vercel-hosted site manually.
 8. Verify the published appcast artifacts are available at the feed host:
    - `https://keyty.app/appcast.xml`
    - `https://github.com/keytyapp/Keyty/releases/download/v<NEW_VERSION>/Keyty.zip`


### PR DESCRIPTION
## Summary

Document the existing automatic appcast website sync in the release guide.
The docs now describe the website dispatch token and repository settings, and
move manual `appcast.xml` publishing to a fallback path when the automation is
not configured or fails.

## Tests

- [x] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: docs-only change; reviewed the release workflow and updated `Docs/RELEASING.md` to match it

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
