### PR TITLE
docs(readme): update Homebrew install command

### DIFF
--- a/Docs/README.de.md
+++ b/Docs/README.de.md
@@ -60,7 +60,7 @@ Laden Sie die neueste Version von [GitHub](https://github.com/keytyapp/Keyty/rel
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Aus dem Quellcode erstellen

--- a/Docs/README.es.md
+++ b/Docs/README.es.md
@@ -60,7 +60,7 @@ Descarga la última versión desde [GitHub](https://github.com/keytyapp/Keyty/re
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Compilar desde el código fuente

--- a/Docs/README.fr.md
+++ b/Docs/README.fr.md
@@ -60,7 +60,7 @@ Téléchargez la dernière version depuis [GitHub](https://github.com/keytyapp/K
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Compiler à partir du code source

--- a/Docs/README.ja.md
+++ b/Docs/README.ja.md
@@ -59,7 +59,7 @@ Keyty は設定画面から、ワークフローやプレゼンテーション�
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### ソースからビルド

--- a/Docs/README.nl.md
+++ b/Docs/README.nl.md
@@ -60,7 +60,7 @@ Download de nieuwste release van [GitHub](https://github.com/keytyapp/Keyty/rele
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Bouwen vanaf de broncode

--- a/Docs/README.pl.md
+++ b/Docs/README.pl.md
@@ -60,7 +60,7 @@ Pobierz najnowsze wydanie z [GitHub](https://github.com/keytyapp/Keyty/releases)
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Kompilacja ze źródeł

--- a/Docs/README.pt-BR.md
+++ b/Docs/README.pt-BR.md
@@ -60,7 +60,7 @@ Baixe a versão mais recente no [GitHub](https://github.com/keytyapp/Keyty/relea
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Compilar a partir do código-fonte

--- a/Docs/README.uk.md
+++ b/Docs/README.uk.md
@@ -60,7 +60,7 @@ Keyty можна налаштувати в Settings відповідно до в
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Збірка з вихідного коду

--- a/Docs/README.zh-Hans.md
+++ b/Docs/README.zh-Hans.md
@@ -59,7 +59,7 @@ Keyty 是一款免费开源应用，可实时可视化你的键盘和鼠标操�
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### 从源码构建

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Download the latest release from [GitHub](https://github.com/keytyapp/Keyty/rele
 ### Homebrew
 
 ```bash
-brew install --cask keytyapp/tap/keyty
+brew install --cask keyty
 ```
 
 ### Build from Source


### PR DESCRIPTION
## Summary

- Replaces the old tap-qualified Homebrew install command with the new canonical `brew install --cask keyty` command.
- Updates the main README and all localized README variants so installation docs stay consistent.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'
- [x] Other: Not run; documentation-only change.

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A
