### PR TITLE
fix(keyboard): round preview sizes to whole points

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerGroupView.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerGroupView.swift
@@ -71,7 +71,14 @@ extension KeyboardVisualizerGroupView {
 // MARK: - NSView
 extension KeyboardVisualizerGroupView {
     var preferredSize: NSSize {
-        NSSize(width: self.baseSize.width * self.scale, height: self.baseSize.height * self.scale)
+        let scaledSize = NSSize(
+            width: self.baseSize.width * self.scale,
+            height: self.baseSize.height * self.scale
+        )
+        return NSSize(
+            width: max(0, scaledSize.width.rounded(.up)),
+            height: max(0, scaledSize.height.rounded(.up))
+        )
     }
 
     override var intrinsicContentSize: NSSize {

--- a/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Keyty
 
+@MainActor
 final class KeyboardSettingsPreviewTests: XCTestCase {
     private var store: InMemoryKeyValueStore!
     private var settings: KeyboardVisualizerSettings!


### PR DESCRIPTION
## Summary

Round keyboard preview sizes up to whole points before SwiftUI consumes them.
Add a regression test to keep preview sizes integral across keycap styles.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeyboardSettingsPreviewTests`

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Fix a keyboard settings preview layout warning that could appear for some theme/style combinations.
