### PR TITLE
docs(readme): align mouse demo image layout across readmes

### DIFF
--- a/Docs/README.de.md
+++ b/Docs/README.de.md
@@ -33,12 +33,9 @@ Keyty ist eine kostenlose Open-Source-App, die Ihre Tastatur- und Mausaktionen i
 ### Maus
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="Demo des Zeigerrings" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="Demo des Zeigersymbols" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="Demo der Mausklick-Wellen" width="720">
+  <img src="Resources/ring_demo.gif" alt="Demo des Zeigerrings" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="Demo des Zeigersymbols" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="Demo der Mausklick-Wellen" width="33%">
 </p>
 
 - Visualisieren Sie Mausklicks und Scrollaktionen zusammen mit der Tastatureingabe

--- a/Docs/README.es.md
+++ b/Docs/README.es.md
@@ -33,12 +33,9 @@ Keyty es una app gratuita y de código abierto que visualiza tus acciones de tec
 ### Ratón
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="Demostración del anillo del puntero" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="Demostración del icono del puntero" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="Demostración de ondas de clic del ratón" width="720">
+  <img src="Resources/ring_demo.gif" alt="Demostración del anillo del puntero" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="Demostración del icono del puntero" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="Demostración de ondas de clic del ratón" width="33%">
 </p>
 
 - Visualiza clics y acciones de desplazamiento del ratón junto con la entrada del teclado

--- a/Docs/README.fr.md
+++ b/Docs/README.fr.md
@@ -33,12 +33,9 @@ Keyty est une application gratuite et open source qui visualise vos actions au c
 ### Souris
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="Démo de l'anneau du pointeur" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="Démo de l'icône du pointeur" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="Démo des ondes de clic de la souris" width="720">
+  <img src="Resources/ring_demo.gif" alt="Démo de l'anneau du pointeur" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="Démo de l'icône du pointeur" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="Démo des ondes de clic de la souris" width="33%">
 </p>
 
 - Visualisez les clics et actions de défilement de la souris en plus des entrées clavier

--- a/Docs/README.ja.md
+++ b/Docs/README.ja.md
@@ -32,12 +32,9 @@ Keyty は、キーボードやマウスの操作をリアルタイムで可視�
 ### マウス
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="ポインターリングのデモ" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="ポインターアイコンのデモ" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="マウスクリックのリップルデモ" width="720">
+  <img src="Resources/ring_demo.gif" alt="ポインターリングのデモ" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="ポインターアイコンのデモ" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="マウスクリックのリップルデモ" width="33%">
 </p>
 
 - キーボード入力とあわせてマウスクリックやスクロール操作を可視化

--- a/Docs/README.nl.md
+++ b/Docs/README.nl.md
@@ -33,12 +33,9 @@ Keyty is een gratis open-source-app die je toetsenbord- en muisacties in realtim
 ### Muis
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="Demo van de aanwijzerring" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="Demo van het aanwijzerpictogram" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="Demo van muisklikrimpels" width="720">
+  <img src="Resources/ring_demo.gif" alt="Demo van de aanwijzerring" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="Demo van het aanwijzerpictogram" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="Demo van muisklikrimpels" width="33%">
 </p>
 
 - Visualiseer muisklikken en scrollacties naast toetsenbordinvoer

--- a/Docs/README.pl.md
+++ b/Docs/README.pl.md
@@ -33,12 +33,9 @@ Keyty to darmowa aplikacja open source, która wizualizuje działania klawiatury
 ### Mysz
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="Demo pierścienia wskaźnika" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="Demo ikony wskaźnika" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="Demo fal kliknięcia myszy" width="720">
+  <img src="Resources/ring_demo.gif" alt="Demo pierścienia wskaźnika" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="Demo ikony wskaźnika" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="Demo fal kliknięcia myszy" width="33%">
 </p>
 
 - Wizualizacja kliknięć myszy i przewijania obok wejścia z klawiatury

--- a/Docs/README.pt-BR.md
+++ b/Docs/README.pt-BR.md
@@ -33,12 +33,9 @@ Keyty é um app gratuito e de código aberto que visualiza suas ações de tecla
 ### Mouse
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="Demonstração do anel do ponteiro" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="Demonstração do ícone do ponteiro" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="Demonstração das ondas de clique do mouse" width="720">
+  <img src="Resources/ring_demo.gif" alt="Demonstração do anel do ponteiro" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="Demonstração do ícone do ponteiro" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="Demonstração das ondas de clique do mouse" width="33%">
 </p>
 
 - Visualize cliques e ações de rolagem do mouse junto com a entrada do teclado

--- a/Docs/README.uk.md
+++ b/Docs/README.uk.md
@@ -33,12 +33,9 @@ Keyty — це безкоштовна програма з відкритим к�
 ### Миша
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="Демонстрація кільця вказівника" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="Демонстрація значка вказівника" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="Демонстрація хвиль кліку миші" width="720">
+  <img src="Resources/ring_demo.gif" alt="Демонстрація кільця вказівника" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="Демонстрація значка вказівника" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="Демонстрація хвиль кліку миші" width="33%">
 </p>
 
 - Візуалізація кліків і прокручування миші разом із клавіатурним введенням

--- a/Docs/README.zh-Hans.md
+++ b/Docs/README.zh-Hans.md
@@ -32,12 +32,9 @@ Keyty 是一款免费开源应用，可实时可视化你的键盘和鼠标操�
 ### 鼠标
 
 <p>
-  <img src="Resources/ring_demo.gif" alt="指针高亮环演示" width="49%">
-  <img src="Resources/pointer_icon_demo.gif" alt="指针图标演示" width="49%">
-</p>
-
-<p align="center">
-  <img src="Resources/mouse_ripples_demo.gif" alt="鼠标点击波纹演示" width="720">
+  <img src="Resources/ring_demo.gif" alt="指针高亮环演示" width="33%">
+  <img src="Resources/pointer_icon_demo.gif" alt="指针图标演示" width="33%">
+  <img src="Resources/mouse_ripples_demo.gif" alt="鼠标点击波纹演示" width="33%">
 </p>
 
 - 与键盘输入一起可视化鼠标点击和滚动操作

--- a/README.md
+++ b/README.md
@@ -45,12 +45,9 @@ Keyty is a free, open-source app that visualizes your keyboard and mouse actions
 ### Mouse
 
 <p>
-  <img src="Docs/Resources/ring_demo.gif" alt="Pointer ring demo" width="49%">
-  <img src="Docs/Resources/pointer_icon_demo.gif" alt="Pointer icon demo" width="49%">
-</p>
-
-<p align="center">
-  <img src="Docs/Resources/mouse_ripples_demo.gif" alt="Mouse ripples demo" width="720">
+  <img src="Docs/Resources/ring_demo.gif" alt="Pointer ring demo" width="33%">
+  <img src="Docs/Resources/pointer_icon_demo.gif" alt="Pointer icon demo" width="33%">
+  <img src="Docs/Resources/mouse_ripples_demo.gif" alt="Mouse ripples demo" width="33%">
 </p>
 
 - Visualize mouse clicks and scroll actions alongside keyboard input


### PR DESCRIPTION
## Summary

Align the mouse demo section across the main README and localized README files.
Replace the separate mouse ripples block with a single three-image row so all mouse demos use the same layout.

## Tests

- [ ] tuist generate
- [ ] xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'
- [ ] Other:

Run project commands from Apps/Keyty.

## UI Changes

Attach screenshots or screen recordings for visible UI changes. Write N/A if there are none.

| Before | After |
| --- | --- |
| Two-image row plus separate ripples image | Single three-image row for mouse demos |

## Documentation

- [x] Updated relevant docs
- [ ] No docs needed

## Release Notes

N/A