### PR TITLE
feat(keyboard-visualizer): add reversed group order setting

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPane.swift
@@ -217,6 +217,19 @@ struct KeyboardSettingsPane: View {
                         .toggleStyle(.switch)
                         .controlSize(.small)
                 }
+
+                Divider()
+
+                SettingsControlRow(
+                    title: L10n.KeyboardVisualizer.reverseOrderLabel,
+                    subtitle: L10n.KeyboardVisualizer.reverseOrderSubtitle
+                ) {
+                    Toggle("", isOn: self.$model.isReversed)
+                        .labelsHidden()
+                        .accessibilityLabel(L10n.KeyboardVisualizer.reverseOrderLabel)
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
             }
             .disabled(!self.model.isEnabled)
 

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPaneViewModel.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Keyboard/KeyboardSettingsPaneViewModel.swift
@@ -37,6 +37,10 @@ final class KeyboardSettingsPaneViewModel: ObservableObject {
         didSet { self.settings.maxCount = self.maxCount }
     }
 
+    @Published var isReversed: Bool {
+        didSet { self.settings.isReversed = self.isReversed }
+    }
+
     @Published var fadeDelay: Double {
         didSet { self.settings.fadeDelay = CGFloat(self.fadeDelay) }
     }
@@ -182,6 +186,7 @@ final class KeyboardSettingsPaneViewModel: ObservableObject {
         self.stackAxis = settings.stackAxis
         self.anchor = settings.anchor
         self.maxCount = settings.maxCount
+        self.isReversed = settings.isReversed
         self.fadeDelay = Double(settings.fadeDelay)
         self.fadeDuration = Double(settings.fadeDuration)
         self.theme = settings.theme
@@ -249,6 +254,7 @@ final class KeyboardSettingsPaneViewModel: ObservableObject {
         settings.stackAxis = self.stackAxis
         settings.anchor = self.anchor
         settings.maxCount = self.maxCount
+        settings.isReversed = self.isReversed
         settings.fadeDelay = CGFloat(self.fadeDelay)
         settings.fadeDuration = CGFloat(self.fadeDuration)
         settings.scale = Self.previewScale

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettings.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettings.swift
@@ -14,6 +14,7 @@ protocol KeyboardVisualizerSettingsProtocol: AnyObject {
     
     var stackAxis: KeyboardVisualizerStackAxis { get set }
     var maxCount: Int { get set }
+    var isReversed: Bool { get set }
     
     var fadeDelay: CGFloat { get set }
     var fadeDuration: CGFloat { get set }
@@ -164,6 +165,16 @@ final class KeyboardVisualizerSettings: KeyboardVisualizerSettingsProtocol, HasS
     var maxCount: Int {
         get { self.storedMaxCount > 0 ? self.storedMaxCount : KeyboardVisualizerSettingsKeys.defaultMaxCount }
         set { self.storedMaxCount = max(KeyboardVisualizerSettingsKeys.minMaxCount, newValue) }
+    }
+
+    /// Whether groups stack away from the anchored edge, placing the newest group
+    /// at the end of the stack instead of the beginning.
+    @Stored(.bool(KeyboardVisualizerSettingsKeys.isReversed, default: false))
+    var isReversed: Bool {
+        didSet {
+            guard self.isReversed != oldValue else { return }
+            self.placementChangesSubject.send(())
+        }
     }
 
     @Stored(.cgFloat(KeyboardVisualizerSettingsKeys.fadeDelay, default: 2.0))

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettingsKeys.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettingsKeys.swift
@@ -13,8 +13,11 @@ enum KeyboardVisualizerSettingsKeys {
     static let minMaxCount = 1
 
     static let isEnabled    = "keyboard_visualizer.isEnabled"
+    
     static let axis         = "keyboard_visualizer.direction"
     static let maxCount     = "keyboard_visualizer.maxCount"
+    static let isReversed   = "keyboard_visualizer.isReversed"
+    
     static let fadeDelay    = "keyboard_visualizer.fadeDelay"
     static let fadeDuration = "keyboard_visualizer.fadeDuration"
     static let theme        = "keyboard_visualizer.theme"

--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerWindow.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerWindow.swift
@@ -18,6 +18,10 @@ final class KeyboardVisualizerWindow: NSWindow {
     var onGroupRemoved: ((KeyboardVisualizerGroupView) -> Void)?
     var groupCount: Int { self.groupViews.count }
 
+    var orderedGroupViews: [KeyboardVisualizerGroupView] {
+        self.settings.isReversed ? self.groupViews : self.groupViews.reversed()
+    }
+
     init(
         settings: KeyboardVisualizerSettings = KeyboardVisualizerSettings(),
         screensService: any ScreenServiceProvider = ScreensService.shared
@@ -125,8 +129,7 @@ final class KeyboardVisualizerWindow: NSWindow {
         let alignment = self.settings.alignment
         let spacing = Size.KeyboardVisualizer.groupSpacing
             * self.settings.style.sizeNormalization * self.settings.scale
-        let orderedViews = self.groupViews.reversed()
-        let viewSizes = orderedViews.map { ($0, $0.preferredSize) }
+        let viewSizes = self.orderedGroupViews.map { ($0, $0.preferredSize) }
         var cursor = CGPoint.zero
         var contentSize = NSSize.zero
 

--- a/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/de.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Nur Tasten anzeigen, die mit Befehl, Control, Wahltaste oder Umschalttaste gedrückt werden.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Wiederholte Gruppen zusammenfassen";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Zeigt eine Zählmarke an, wenn dieselbe Taste oder Tastenkombination mehrfach hintereinander gedrückt wird.";
+"keyboard_visualizer.reverse_order_label" = "Reihenfolge umkehren";
+"keyboard_visualizer.reverse_order_subtitle" = "Neue Gruppen am Ende des Stapels statt am Anfang hinzufügen.";
 "keyboard_visualizer.show_special_keys_label" = "Sondertasten";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tabulator, Eingabetaste, Pfeile, fn, Funktionstasten und ähnliche Tasten.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Medientasten";

--- a/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/en.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Only show keys pressed with Command, Control, Option, or Shift.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Collapse repeated groups";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Show a count badge when the same key or key combination is pressed repeatedly in a row.";
+"keyboard_visualizer.reverse_order_label" = "Reverse order";
+"keyboard_visualizer.reverse_order_subtitle" = "Add new groups to the end of the stack instead of the beginning.";
 "keyboard_visualizer.show_special_keys_label" = "Special keys";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab, return, arrows, fn, function keys, and similar keys.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Media key buttons";

--- a/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/es.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Muestra solo las teclas pulsadas con Comando, Control, Opción o Mayúsculas.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Agrupar repeticiones consecutivas";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Muestra una insignia con el recuento cuando la misma tecla o combinación se pulsa repetidamente en una fila.";
+"keyboard_visualizer.reverse_order_label" = "Invertir el orden";
+"keyboard_visualizer.reverse_order_subtitle" = "Añade los grupos nuevos al final de la pila en lugar del principio.";
 "keyboard_visualizer.show_special_keys_label" = "Teclas especiales";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tabulador, Retorno, flechas, fn, teclas de función y otras similares.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Teclas multimedia";

--- a/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/fr.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Afficher uniquement les touches utilisées avec Commande, Contrôle, Option ou Majuscule.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Regrouper les répétitions consécutives";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Affiche un badge de compteur lorsque la même touche ou combinaison est pressée plusieurs fois de suite.";
+"keyboard_visualizer.reverse_order_label" = "Inverser l’ordre";
+"keyboard_visualizer.reverse_order_subtitle" = "Ajoute les nouveaux groupes à la fin de la pile plutôt qu’au début.";
 "keyboard_visualizer.show_special_keys_label" = "Touches spéciales";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tabulation, Retour, flèches, fn, touches de fonction et touches similaires.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Touches multimédias";

--- a/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/ja.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Command、Control、Option、Shiftのいずれかと同時に押したキーのみ表示します。";
 "keyboard_visualizer.collapse_repeated_groups_label" = "連続する同一グループをまとめる";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "同じキーまたはキーの組み合わせが連続して押されたときに、回数バッジを表示します。";
+"keyboard_visualizer.reverse_order_label" = "順序を反転";
+"keyboard_visualizer.reverse_order_subtitle" = "新しいグループをスタックの先頭ではなく末尾に追加します。";
 "keyboard_visualizer.show_special_keys_label" = "特殊キー";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab、Return、矢印、fn、ファンクションキーなどを表示します。";
 "keyboard_visualizer.show_media_key_buttons_label" = "メディアキー";

--- a/Apps/Keyty/Sources/Keyty/Resources/ko.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/ko.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Command, Control, Option 또는 Shift와 함께 눌린 키만 표시합니다.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "반복 그룹 접기";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "같은 키 또는 키 조합이 연속으로 반복되면 개수 배지를 표시합니다.";
+"keyboard_visualizer.reverse_order_label" = "순서 반전";
+"keyboard_visualizer.reverse_order_subtitle" = "새 그룹을 스택의 앞이 아닌 끝에 추가합니다.";
 "keyboard_visualizer.show_special_keys_label" = "특수 키";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab, Return, 화살표, fn, 기능 키 등과 비슷한 키입니다.";
 "keyboard_visualizer.show_media_key_buttons_label" = "미디어 키 버튼";

--- a/Apps/Keyty/Sources/Keyty/Resources/nl.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/nl.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Toon alleen toetsen die met Command, Control, Option of Shift worden ingedrukt.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Herhaalde groepen samenvoegen";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Toon een telbadge wanneer dezelfde toets of toetscombinatie meerdere keren achter elkaar wordt ingedrukt.";
+"keyboard_visualizer.reverse_order_label" = "Volgorde omkeren";
+"keyboard_visualizer.reverse_order_subtitle" = "Voegt nieuwe groepen toe aan het einde van de stapel in plaats van aan het begin.";
 "keyboard_visualizer.show_special_keys_label" = "Speciale toetsen";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab, Return, pijlen, fn, functietoetsen en vergelijkbare toetsen.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Mediatoetsen";

--- a/Apps/Keyty/Sources/Keyty/Resources/pl.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/pl.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Pokazuj tylko klawisze naciśnięte z Command, Control, Option lub Shift.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Scalaj powtarzające się grupy";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Pokazuje plakietkę z liczbą, gdy ten sam klawisz lub kombinacja klawiszy jest naciskana kolejno wiele razy.";
+"keyboard_visualizer.reverse_order_label" = "Odwróć kolejność";
+"keyboard_visualizer.reverse_order_subtitle" = "Dodaje nowe grupy na końcu stosu zamiast na początku.";
 "keyboard_visualizer.show_special_keys_label" = "Klawisze specjalne";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab, return, strzałki, fn, klawisze funkcyjne i podobne.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Klawisze multimedialne";

--- a/Apps/Keyty/Sources/Keyty/Resources/pt-BR.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/pt-BR.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Mostre apenas teclas pressionadas com Command, Control, Option ou Shift.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Agrupar repetições consecutivas";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Mostra um selo de contagem quando a mesma tecla ou combinação é pressionada repetidamente em sequência.";
+"keyboard_visualizer.reverse_order_label" = "Inverter a ordem";
+"keyboard_visualizer.reverse_order_subtitle" = "Adiciona os grupos novos no fim da pilha em vez do início.";
 "keyboard_visualizer.show_special_keys_label" = "Teclas especiais";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab, Return, setas, fn, teclas de função e semelhantes.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Teclas de mídia";

--- a/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/uk.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "Показувати лише клавіші, натиснуті разом із Command, Control, Option або Shift.";
 "keyboard_visualizer.collapse_repeated_groups_label" = "Об’єднувати повторювані групи";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "Показує бейдж із кількістю, коли ту саму клавішу або комбінацію клавіш натискають кілька разів поспіль.";
+"keyboard_visualizer.reverse_order_label" = "Зворотний порядок";
+"keyboard_visualizer.reverse_order_subtitle" = "Додає нові групи в кінець стосу, а не на початок.";
 "keyboard_visualizer.show_special_keys_label" = "Спеціальні клавіші";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab, Return, стрілки, fn, функціональні та подібні клавіші.";
 "keyboard_visualizer.show_media_key_buttons_label" = "Мультимедійні клавіші";

--- a/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Apps/Keyty/Sources/Keyty/Resources/zh-Hans.lproj/Localizable.strings
@@ -132,6 +132,8 @@
 "keyboard_visualizer.only_show_modified_keystrokes_subtitle" = "仅显示与 Command、Control、Option 或 Shift 同时按下的按键。";
 "keyboard_visualizer.collapse_repeated_groups_label" = "合并连续重复分组";
 "keyboard_visualizer.collapse_repeated_groups_subtitle" = "当同一按键或组合键连续重复按下时，显示计数徽标。";
+"keyboard_visualizer.reverse_order_label" = "反转顺序";
+"keyboard_visualizer.reverse_order_subtitle" = "将新分组添加到堆叠末尾，而不是开头。";
 "keyboard_visualizer.show_special_keys_label" = "特殊按键";
 "keyboard_visualizer.show_special_keys_subtitle" = "Tab、Return、箭头、fn、功能键及类似按键。";
 "keyboard_visualizer.show_media_key_buttons_label" = "媒体按键";

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSettingsTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSettingsTests.swift
@@ -46,6 +46,7 @@ final class KeyboardVisualizerSettingsTests: XCTestCase {
         XCTAssertEqual(self.store.double(forKey: KeyboardVisualizerSettingsKeys.windowPadding), Double(Size.KeyboardVisualizer.windowPadding), accuracy: 0.0001)
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.onlyShowModifiedKeystrokes), false)
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.collapseRepeatedGroups), false)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.isReversed), false)
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showSpecialKeys), true)
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMediaKeyButtons), true)
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMouseEvents), true)
@@ -297,6 +298,26 @@ final class KeyboardVisualizerSettingsTests: XCTestCase {
 
         XCTAssertTrue(self.settings.collapseRepeatedGroups)
         XCTAssertTrue(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.collapseRepeatedGroups))
+    }
+
+    func testPersistsIsReversed() {
+        self.settings.isReversed = true
+
+        XCTAssertTrue(self.settings.isReversed)
+        XCTAssertTrue(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.isReversed))
+    }
+
+    func testPublishesPlacementChangeWhenReversedOrderChanges() {
+        var receivedCount = 0
+        let cancellable = self.settings.placementChanges.sink { _ in
+            receivedCount += 1
+        }
+
+        self.settings.isReversed = true
+        self.settings.isReversed = true
+
+        XCTAssertEqual(receivedCount, 1)
+        cancellable.cancel()
     }
 
     func testPersistsShowSpecialKeys() {


### PR DESCRIPTION
## Summary

Add a keyboard-visualizer setting that reverses the display order of grouped input.
Persist the preference, apply it to live keyboard rendering, expose it in Settings, and localize its label.

Addresses https://github.com/keytyapp/Keyty/issues/140

## Tests

- [ ] tuist generate
- [ ] xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'
- [x] Other:

Focused XCTest coverage was added for the persisted setting. Project commands were not run for this PR.

Run project commands from Apps/Keyty.

## UI Changes

https://github.com/user-attachments/assets/119f4dc0-af93-46d2-8604-400829ab3bd9

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Add reversed group order setting for the keyboard visualizer.