### PR TITLE
fix(settings): disable mouse events by default

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettings.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizerSettings.swift
@@ -362,7 +362,7 @@ final class KeyboardVisualizerSettings: KeyboardVisualizerSettingsProtocol, HasS
     var showMediaKeyButtons: Bool
 
     /// Whether mouse clicks and wheel events should be rendered in the keyboard overlay.
-    @Stored(.bool(KeyboardVisualizerSettingsKeys.showMouseEvents, default: true))
+    @Stored(.bool(KeyboardVisualizerSettingsKeys.showMouseEvents, default: false))
     var showMouseEvents: Bool
 
     var themeTokens: KeycapThemeTokens {

--- a/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Settings/Keyboard/KeyboardSettingsPreviewTests.swift
@@ -28,6 +28,8 @@ final class KeyboardSettingsPreviewTests: XCTestCase {
     }
 
     func testPreviewGroupsIncludeAllEnabledCategories() {
+        settings.showMouseEvents = true
+
         let groups = KeyboardSettingsPane.PreviewGroup.previewGroups(settings: settings)
 
         XCTAssertEqual(groups.map(\.category), [
@@ -41,6 +43,7 @@ final class KeyboardSettingsPreviewTests: XCTestCase {
 
     func testPreviewGroupsOmitPlainKeyCategoryWhenShowingModifiedKeystrokesOnly() {
         settings.onlyShowModifiedKeystrokes = true
+        settings.showMouseEvents = true
 
         let groups = KeyboardSettingsPane.PreviewGroup.previewGroups(settings: settings)
 
@@ -54,6 +57,7 @@ final class KeyboardSettingsPreviewTests: XCTestCase {
 
     func testPreviewGroupsOmitSpecialKeyCategoryWhenDisabled() {
         settings.showSpecialKeys = false
+        settings.showMouseEvents = true
 
         let groups = KeyboardSettingsPane.PreviewGroup.previewGroups(settings: settings)
 
@@ -67,6 +71,7 @@ final class KeyboardSettingsPreviewTests: XCTestCase {
 
     func testPreviewGroupsOmitMediaCategoryWhenDisabled() {
         settings.showMediaKeyButtons = false
+        settings.showMouseEvents = true
 
         let groups = KeyboardSettingsPane.PreviewGroup.previewGroups(settings: settings)
 

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSettingsTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerSettingsTests.swift
@@ -48,7 +48,7 @@ final class KeyboardVisualizerSettingsTests: XCTestCase {
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.collapseRepeatedGroups), false)
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showSpecialKeys), true)
         XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMediaKeyButtons), true)
-        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMouseEvents), true)
+        XCTAssertEqual(self.store.bool(forKey: KeyboardVisualizerSettingsKeys.showMouseEvents), false)
     }
 
     func testSharedKeyboardVisualizerSettingsFallbackAndClamping() {


### PR DESCRIPTION
## Summary

Disables keyboard-overlay mouse events by default for new and reset settings.

## Tests

- [ ] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'` (interrupted)
- [x] Other: Updated focused default-registration XCTest coverage.

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Mouse events in the keyboard overlay are now disabled by default.
