### PR TITLE
feat(app): show settings when reopening app

### DIFF
--- a/Apps/Keyty/Sources/Keyty/App/Lifecycle/AppController.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Lifecycle/AppController.swift
@@ -81,6 +81,11 @@ extension AppController: NSApplicationDelegate {
 
         self.dependencies.captureController.stopCapturing()
     }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        self.showSettingsWindow(self)
+        return false
+    }
 }
 
 // MARK: - Settings Presentation


### PR DESCRIPTION
## Summary

Show Settings window when an already-running instance receives a macOS reopen event, such as a subsequent launch from Raycast. This provides a keyboard-first path to Settings even when the menu bar is not accessible.

Implements https://github.com/keytyapp/Keyty/issues/144

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Run project commands from `Apps/Keyty`.

## UI Changes

https://github.com/user-attachments/assets/f2fc1baa-9d1b-4c46-a11a-46cf2cb6fb50

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Reopening an already-running Keyty now brings up Settings.