### PR TITLE
feat(app-store): add sandboxed App Store scheme

### DIFF
--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -55,6 +55,16 @@ let appReleaseSettings: SettingsDictionary = [
     "GCC_MODEL_TUNING": "G5",
 ]
 
+// This configuration is intentionally separate from Release. Release produces
+// the Developer ID-signed, notarized build used for direct distribution.
+// AppStore is the sandboxed build that will be archived for App Store Connect.
+let appStoreSettings: SettingsDictionary = [
+    "CODE_SIGN_ENTITLEMENTS": "Sources/Keyty/Resources/AppStore.entitlements",
+    "CODE_SIGN_STYLE": "Automatic",
+    "DEVELOPMENT_TEAM": "NEVA4MAZBL",
+    "GCC_MODEL_TUNING": "G5",
+]
+
 let testSettings: SettingsDictionary = [
     "BUNDLE_LOADER": "$(TEST_HOST)",
     "CLANG_ANALYZER_NONNULL": "YES",
@@ -164,6 +174,12 @@ let projectSettings = Settings.settings(
                 "SWIFT_COMPILATION_MODE": "wholemodule",
             ]
         ),
+        .release(
+            name: "AppStore",
+            settings: [
+                "SWIFT_COMPILATION_MODE": "wholemodule",
+            ]
+        ),
     ]
 )
 
@@ -222,6 +238,7 @@ let project = Project(
                 configurations: [
                     .debug(name: "Debug", settings: appDebugSettings),
                     .release(name: "Release", settings: appReleaseSettings),
+                    .release(name: "AppStore", settings: appStoreSettings),
                 ]
             )
         ),
@@ -263,6 +280,15 @@ let project = Project(
             runAction: .runAction(configuration: .debug),
             archiveAction: .archiveAction(configuration: .release),
             profileAction: .profileAction(configuration: .release),
+            analyzeAction: .analyzeAction(configuration: .debug)
+        ),
+        .scheme(
+            name: "Keyty AppStore",
+            shared: true,
+            buildAction: .buildAction(targets: ["Keyty"]),
+            runAction: .runAction(configuration: "AppStore"),
+            archiveAction: .archiveAction(configuration: "AppStore"),
+            profileAction: .profileAction(configuration: "AppStore"),
             analyzeAction: .analyzeAction(configuration: .debug)
         ),
     ],

--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -70,6 +70,12 @@ let appStoreSettings: SettingsDictionary = [
     ],
 ]
 
+let appStoreDebugSettings = appStoreSettings.merging([
+    "PRODUCT_NAME": "KeytyAppStore",
+]) { _, appStoreDebugValue in
+    appStoreDebugValue
+}
+
 let testSettings: SettingsDictionary = [
     "BUNDLE_LOADER": "$(TEST_HOST)",
     "CLANG_ANALYZER_NONNULL": "YES",
@@ -225,7 +231,10 @@ let project = Project(
             buildableFolders: [
                 .folder(
                     "Sources/Keyty",
-                    exceptions: [.exception(excluded: ["Resources/Info.plist"])]
+                    exceptions: [.exception(excluded: [
+                        "Resources/Info.plist",
+                        "Resources/AppStore-Info.plist",
+                    ])]
                 ),
             ],
             entitlements: .file(path: "Sources/Keyty/Resources/Keyty.entitlements"),
@@ -252,11 +261,14 @@ let project = Project(
             product: .app,
             bundleId: "app.keyty.Keyty.AppStore",
             deploymentTargets: .macOS("11.0"),
-            infoPlist: .file(path: "Sources/Keyty/Resources/Info.plist"),
+            infoPlist: .file(path: "Sources/Keyty/Resources/AppStore-Info.plist"),
             buildableFolders: [
                 .folder(
                     "Sources/Keyty",
-                    exceptions: [.exception(excluded: ["Resources/Info.plist"])]
+                    exceptions: [.exception(excluded: [
+                        "Resources/Info.plist",
+                        "Resources/AppStore-Info.plist",
+                    ])]
                 ),
             ],
             entitlements: .file(path: "Sources/Keyty/Resources/AppStore.entitlements"),
@@ -266,13 +278,11 @@ let project = Project(
                 .sdk(name: "QuartzCore", type: .framework),
                 .sdk(name: "Carbon", type: .framework),
                 .package(product: "ShortcutRecorder"),
-                .package(product: "Sparkle"),
-                .package(product: "AppMover"),
             ],
             settings: .settings(
                 base: appSettings,
                 configurations: [
-                    .debug(name: "Debug", settings: appStoreSettings),
+                    .debug(name: "Debug", settings: appStoreDebugSettings),
                     .release(name: "AppStore", settings: appStoreSettings),
                 ]
             )

--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -63,6 +63,11 @@ let appStoreSettings: SettingsDictionary = [
     "CODE_SIGN_STYLE": "Automatic",
     "DEVELOPMENT_TEAM": "NEVA4MAZBL",
     "GCC_MODEL_TUNING": "G5",
+    "PRODUCT_BUNDLE_IDENTIFIER": "app.keyty.Keyty.AppStore",
+    "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
+        "$(inherited)",
+        "APP_STORE",
+    ],
 ]
 
 let testSettings: SettingsDictionary = [
@@ -238,6 +243,36 @@ let project = Project(
                 configurations: [
                     .debug(name: "Debug", settings: appDebugSettings),
                     .release(name: "Release", settings: appReleaseSettings),
+                ]
+            )
+        ),
+        .target(
+            name: "KeytyAppStore",
+            destinations: .macOS,
+            product: .app,
+            bundleId: "app.keyty.Keyty.AppStore",
+            deploymentTargets: .macOS("11.0"),
+            infoPlist: .file(path: "Sources/Keyty/Resources/Info.plist"),
+            buildableFolders: [
+                .folder(
+                    "Sources/Keyty",
+                    exceptions: [.exception(excluded: ["Resources/Info.plist"])]
+                ),
+            ],
+            entitlements: .file(path: "Sources/Keyty/Resources/AppStore.entitlements"),
+            dependencies: [
+                .sdk(name: "Cocoa", type: .framework),
+                .sdk(name: "Quartz", type: .framework),
+                .sdk(name: "QuartzCore", type: .framework),
+                .sdk(name: "Carbon", type: .framework),
+                .package(product: "ShortcutRecorder"),
+                .package(product: "Sparkle"),
+                .package(product: "AppMover"),
+            ],
+            settings: .settings(
+                base: appSettings,
+                configurations: [
+                    .debug(name: "Debug", settings: appStoreSettings),
                     .release(name: "AppStore", settings: appStoreSettings),
                 ]
             )
@@ -285,7 +320,7 @@ let project = Project(
         .scheme(
             name: "Keyty AppStore",
             shared: true,
-            buildAction: .buildAction(targets: ["Keyty"]),
+            buildAction: .buildAction(targets: ["KeytyAppStore"]),
             runAction: .runAction(configuration: "AppStore"),
             archiveAction: .archiveAction(configuration: "AppStore"),
             profileAction: .profileAction(configuration: "AppStore"),

--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -198,6 +198,7 @@ let project = Project(
     name: "Keyty",
     organizationName: "Keyty",
     options: .options(
+        automaticSchemesOptions: .disabled,
         defaultKnownRegions: ["de", "en", "es", "fr", "it", "ja", "ko", "nl", "pt-BR", "uk", "zh-Hans"],
         developmentRegion: "en"
     ),

--- a/Apps/Keyty/Sources/Keyty/App/Composition/AppDependencies.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Composition/AppDependencies.swift
@@ -7,7 +7,6 @@
 //
 
 import AppKit
-import Sparkle
 
 @MainActor
 final class AppDependencies {
@@ -23,7 +22,7 @@ final class AppDependencies {
 
     init(
         statusShortcutItem: NSMenuItem,
-        updater: SPUUpdater,
+        updateService: any UpdateService,
         keyValueStore: KeyValueStore = UserDefaultsStore()
     ) {
         self.settings = AppSettingsContainer(store: keyValueStore)
@@ -34,7 +33,7 @@ final class AppDependencies {
         self.ui = AppUIContainer(
             settings: self.settings,
             services: self.services,
-            updater: updater
+            updateService: updateService
         )
     }
 }

--- a/Apps/Keyty/Sources/Keyty/App/Composition/AppUIContainer.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Composition/AppUIContainer.swift
@@ -6,8 +6,6 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-import Sparkle
-
 @MainActor
 final class AppUIContainer {
     let aboutWindowController: AboutWindowController
@@ -18,7 +16,7 @@ final class AppUIContainer {
     init(
         settings: AppSettingsContainer,
         services: AppServiceContainer,
-        updater: SPUUpdater
+        updateService: any UpdateService
     ) {
         self.aboutWindowController = AboutWindowController()
         let keyboardVisualizerPlacementWindowController = KeyboardVisualizerPlacementWindowController(
@@ -34,7 +32,7 @@ final class AppUIContainer {
             pointerRingVisualizer: services.pointerVisualizersManager.ring,
             pointerRipplesVisualizer: services.pointerVisualizersManager.ripples,
             permissionsService: services.permissionsService,
-            updater: updater,
+            updateService: updateService,
             placementCoordinator: keyboardVisualizerPlacementWindowController
         )
         let settingsWindowController = SettingsWindowController(context: settingsContext)

--- a/Apps/Keyty/Sources/Keyty/App/Lifecycle/AppController.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Lifecycle/AppController.swift
@@ -7,22 +7,20 @@
 //
 
 import AppKit
+
+#if !APP_STORE
 import AppMover
-import Sparkle
+#endif
 
 @MainActor
 final class AppController: NSObject {
     private let menuController: MenuController
     private let statusItemController: StatusItemController
     private let dependencies: AppDependencies
-    private let updaterController: SPUStandardUpdaterController
+    private let updateService: any UpdateService
 
     override init() {
-        self.updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
+        self.updateService = UpdateServiceFactory.make()
         self.menuController = MenuController()
         let statusShortcutItem = self.menuController.makeStatusShortcutMenuItem()
         self.statusItemController = StatusItemController(
@@ -31,7 +29,7 @@ final class AppController: NSObject {
         )
         self.dependencies = AppDependencies(
             statusShortcutItem: statusShortcutItem,
-            updater: self.updaterController.updater
+            updateService: self.updateService
         )
         super.init()
         self.menuController.setAppController(self)
@@ -51,7 +49,7 @@ extension AppController: NSApplicationDelegate {
 
         NSApp.activate(ignoringOtherApps: true)
 
-        #if !DEBUG
+        #if !DEBUG && !APP_STORE
         if AppMover.moveIfNecessary() {
             return
         }
@@ -86,8 +84,8 @@ extension AppController: NSApplicationDelegate {
 // MARK: - Settings Presentation
 private extension AppController {
     func checkForUpdatesAtLaunchIfNeeded() {
-        guard self.updaterController.updater.automaticallyChecksForUpdates else { return }
-        self.updaterController.updater.checkForUpdatesInBackground()
+        guard self.updateService.automaticallyChecksForUpdates else { return }
+        self.updateService.checkForUpdatesInBackground()
     }
 
     func showSettingsAtLaunchIfNeeded() {

--- a/Apps/Keyty/Sources/Keyty/App/Support/L10n.swift
+++ b/Apps/Keyty/Sources/Keyty/App/Support/L10n.swift
@@ -6,4 +6,8 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
+#if APP_STORE
+typealias L10n = KeytyAppStoreStrings.Localizable
+#else
 typealias L10n = KeytyStrings.Localizable
+#endif

--- a/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowViewModel.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowViewModel.swift
@@ -208,44 +208,44 @@ extension AboutWindowViewModel {
 
 extension AboutWindowViewModel {
     enum LicenseLoader {
-    static func text(
-        named resourceName: String,
-        trimmingLeadingLines linesToTrim: [String] = [],
-        bundle: Bundle = .main
-    ) -> String {
-        let candidates = [
-            bundle.url(forResource: resourceName, withExtension: "txt", subdirectory: "AboutLicenses"),
-            bundle.url(forResource: resourceName, withExtension: "txt")
-        ]
+        static func text(
+            named resourceName: String,
+            trimmingLeadingLines linesToTrim: [String] = [],
+            bundle: Bundle = .main
+        ) -> String {
+            let candidates = [
+                bundle.url(forResource: resourceName, withExtension: "txt", subdirectory: "AboutLicenses"),
+                bundle.url(forResource: resourceName, withExtension: "txt")
+            ]
 
-        for candidate in candidates {
-            guard let url = candidate else { continue }
-            if let text = try? String(contentsOf: url, encoding: .utf8) {
-                return Self.sanitized(text, trimmingLeadingLines: linesToTrim)
-            }
-        }
-
-        return L10n.About.Credits.licenseMissing
-    }
-
-    private static func sanitized(_ text: String, trimmingLeadingLines linesToTrim: [String]) -> String {
-        var lines = text.components(separatedBy: .newlines)
-
-        while let first = lines.first, first.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            lines.removeFirst()
-        }
-
-        for lineToTrim in linesToTrim {
-            guard let first = lines.first else { break }
-            if first.trimmingCharacters(in: .whitespacesAndNewlines) == lineToTrim {
-                lines.removeFirst()
-                while let next = lines.first, next.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    lines.removeFirst()
+            for candidate in candidates {
+                guard let url = candidate else { continue }
+                if let text = try? String(contentsOf: url, encoding: .utf8) {
+                    return Self.sanitized(text, trimmingLeadingLines: linesToTrim)
                 }
             }
+
+            return L10n.About.Credits.licenseMissing
         }
 
-        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-    }
+        private static func sanitized(_ text: String, trimmingLeadingLines linesToTrim: [String]) -> String {
+            var lines = text.components(separatedBy: .newlines)
+
+            while let first = lines.first, first.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                lines.removeFirst()
+            }
+
+            for lineToTrim in linesToTrim {
+                guard let first = lines.first else { break }
+                if first.trimmingCharacters(in: .whitespacesAndNewlines) == lineToTrim {
+                    lines.removeFirst()
+                    while let next = lines.first, next.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        lines.removeFirst()
+                    }
+                }
+            }
+
+            return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowViewModel.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/About/AboutWindowViewModel.swift
@@ -72,28 +72,7 @@ final class AboutWindowViewModel: ObservableObject {
                 ]
             )
         ]
-        self.credits = [
-            Section(
-                title: "Sparkle",
-                subtitle: L10n.About.Credits.sparkleSubtitle,
-                body: LicenseLoader.text(
-                    named: "Sparkle",
-                    trimmingLeadingLines: [
-                        "Sparkle",
-                        "The MIT License (MIT)"
-                    ]
-                )
-            ),
-            Section(
-                title: "AppMover",
-                subtitle: L10n.About.Credits.appMoverSubtitle,
-                body: LicenseLoader.text(
-                    named: "AppMover",
-                    trimmingLeadingLines: [
-                        "MIT License"
-                    ]
-                )
-            ),
+        var credits = [
             Section(
                 title: "ShortcutRecorder",
                 subtitle: L10n.About.Credits.shortcutRecorderSubtitle,
@@ -105,6 +84,37 @@ final class AboutWindowViewModel: ObservableObject {
                 )
             )
         ]
+
+        #if !APP_STORE
+        credits.insert(
+            contentsOf: [
+                Section(
+                    title: "Sparkle",
+                    subtitle: L10n.About.Credits.sparkleSubtitle,
+                    body: LicenseLoader.text(
+                        named: "Sparkle",
+                        trimmingLeadingLines: [
+                            "Sparkle",
+                            "The MIT License (MIT)"
+                        ]
+                    )
+                ),
+                Section(
+                    title: "AppMover",
+                    subtitle: L10n.About.Credits.appMoverSubtitle,
+                    body: LicenseLoader.text(
+                        named: "AppMover",
+                        trimmingLeadingLines: [
+                            "MIT License"
+                        ]
+                    )
+                ),
+            ],
+            at: 0
+        )
+        #endif
+
+        self.credits = credits
     }
 
     var selectedSections: [Section] {

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsContext.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsContext.swift
@@ -6,8 +6,6 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-import Sparkle
-
 @MainActor
 final class SettingsContext {
     let settings: AppSettingsContainer
@@ -15,7 +13,7 @@ final class SettingsContext {
     let pointerRingVisualizer: PointerRingVisualizer
     let pointerRipplesVisualizer: PointerRipplesVisualizer
     let permissionsService: any PermissionsService
-    let updater: SPUUpdater
+    let updateService: any UpdateService
     let placementCoordinator: any KeyboardVisualizerPlacementCoordinating
 
     var appSettings: any AppSettingsProtocol { self.settings.appSettings }
@@ -30,7 +28,7 @@ final class SettingsContext {
         pointerRingVisualizer: PointerRingVisualizer,
         pointerRipplesVisualizer: PointerRipplesVisualizer,
         permissionsService: any PermissionsService,
-        updater: SPUUpdater,
+        updateService: any UpdateService,
         placementCoordinator: any KeyboardVisualizerPlacementCoordinating
     ) {
         self.settings = settings
@@ -38,7 +36,7 @@ final class SettingsContext {
         self.pointerRingVisualizer = pointerRingVisualizer
         self.pointerRipplesVisualizer = pointerRipplesVisualizer
         self.permissionsService = permissionsService
-        self.updater = updater
+        self.updateService = updateService
         self.placementCoordinator = placementCoordinator
     }
 

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsPaneRegistry.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsPaneRegistry.swift
@@ -6,7 +6,6 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-import Sparkle
 import SwiftUI
 
 struct SettingsPaneEntry: Identifiable {
@@ -21,7 +20,7 @@ struct SettingsPaneRegistry {
     let entries: [SettingsPaneEntry]
 
     init(context: SettingsContext, displaysViewModel: DisplaysSettingsPaneViewModel) {
-        self.entries = [
+        var entries = [
             SettingsPaneEntry(
                 id: .general,
                 title: SettingsPaneIdentifier.general.label,
@@ -82,14 +81,22 @@ struct SettingsPaneRegistry {
                     AnyView(PermissionsSettingsPane(permissionsService: context.permissionsService))
                 }
             ),
+        ]
+
+        #if !APP_STORE
+        entries.append(
             SettingsPaneEntry(
                 id: .update,
                 title: SettingsPaneIdentifier.update.label,
                 systemImageName: SettingsPaneIdentifier.update.sfSymbolName,
                 makeView: {
-                    AnyView(UpdateSettingsPane(updater: context.updater))
+                    AnyView(UpdateSettingsPane(updateService: context.updateService))
                 }
-            ),
+            )
+        )
+        #endif
+
+        entries.append(
             SettingsPaneEntry(
                 id: .info,
                 title: SettingsPaneIdentifier.info.label,
@@ -97,8 +104,10 @@ struct SettingsPaneRegistry {
                 makeView: {
                     AnyView(InfoSettingsPane())
                 }
-            ),
-        ]
+            )
+        )
+
+        self.entries = entries
     }
 
     func entry(for identifier: SettingsPaneIdentifier) -> SettingsPaneEntry? {

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsWindowController.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/SettingsWindowController.swift
@@ -8,7 +8,6 @@
 
 import AppKit
 import Combine
-import Sparkle
 import SwiftUI
 
 @MainActor

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Update/UpdateSettingsPane.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Update/UpdateSettingsPane.swift
@@ -6,14 +6,13 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-import Sparkle
 import SwiftUI
 
 struct UpdateSettingsPane: View {
     @StateObject private var model: UpdateSettingsPaneViewModel
 
-    init(updater: SPUUpdater) {
-        _model = StateObject(wrappedValue: UpdateSettingsPaneViewModel(updater: updater))
+    init(updateService: any UpdateService) {
+        _model = StateObject(wrappedValue: UpdateSettingsPaneViewModel(updateService: updateService))
     }
 
     var body: some View {

--- a/Apps/Keyty/Sources/Keyty/Features/Settings/Update/UpdateSettingsPaneViewModel.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Settings/Update/UpdateSettingsPaneViewModel.swift
@@ -6,9 +6,9 @@
 //  SPDX-License-Identifier: BSD-3-Clause
 //
 
-import Sparkle
 import SwiftUI
 
+@MainActor
 final class UpdateSettingsPaneViewModel: ObservableObject {
     private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -16,31 +16,31 @@ final class UpdateSettingsPaneViewModel: ObservableObject {
         return formatter
     }()
 
-    private let updater: SPUUpdater
+    private let updateService: any UpdateService
 
     @Published var automaticallyChecksForUpdates: Bool {
-        didSet { self.updater.automaticallyChecksForUpdates = self.automaticallyChecksForUpdates }
+        didSet { self.updateService.automaticallyChecksForUpdates = self.automaticallyChecksForUpdates }
     }
 
     @Published var sendsSystemProfile: Bool {
-        didSet { self.updater.sendsSystemProfile = self.sendsSystemProfile }
+        didSet { self.updateService.sendsSystemProfile = self.sendsSystemProfile }
     }
 
-    init(updater: SPUUpdater) {
-        self.updater = updater
-        self.automaticallyChecksForUpdates = self.updater.automaticallyChecksForUpdates
-        self.sendsSystemProfile = self.updater.sendsSystemProfile
+    init(updateService: any UpdateService) {
+        self.updateService = updateService
+        self.automaticallyChecksForUpdates = self.updateService.automaticallyChecksForUpdates
+        self.sendsSystemProfile = self.updateService.sendsSystemProfile
     }
 
     var lastCheckedText: String {
-        guard let date = self.updater.lastUpdateCheckDate else {
+        guard let date = self.updateService.lastUpdateCheckDate else {
             return L10n.Update.never
         }
         return Self.dateFormatter.string(from: date)
     }
 
     func checkForUpdates() {
-        self.updater.checkForUpdates()
+        self.updateService.checkForUpdates()
         self.objectWillChange.send()
     }
 }

--- a/Apps/Keyty/Sources/Keyty/Platform/Permissions/Permission.swift
+++ b/Apps/Keyty/Sources/Keyty/Platform/Permissions/Permission.swift
@@ -19,6 +19,7 @@ enum Permission: CaseIterable, Hashable {
     func requestSystemPermission() {
         let key = kAXTrustedCheckOptionPrompt.takeRetainedValue() as String
         AXIsProcessTrustedWithOptions([key: true] as CFDictionary)
+        NSWorkspace.shared.openAccessibilitySettings()
     }
 }
 

--- a/Apps/Keyty/Sources/Keyty/Resources/AppStore-Info.plist
+++ b/Apps/Keyty/Sources/Keyty/Resources/AppStore-Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en_US</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2026 Serhii Bykov</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+</dict>
+</plist>

--- a/Apps/Keyty/Sources/Keyty/Resources/AppStore.entitlements
+++ b/Apps/Keyty/Sources/Keyty/Resources/AppStore.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+</dict>
+</plist>

--- a/Apps/Keyty/Sources/Keyty/Services/Updates/UpdateService.swift
+++ b/Apps/Keyty/Sources/Keyty/Services/Updates/UpdateService.swift
@@ -1,0 +1,91 @@
+//
+//  UpdateService.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Foundation
+
+#if !APP_STORE
+import Sparkle
+#endif
+
+@MainActor
+protocol UpdateService: AnyObject {
+    var automaticallyChecksForUpdates: Bool { get set }
+    var sendsSystemProfile: Bool { get set }
+    var lastUpdateCheckDate: Date? { get }
+
+    func checkForUpdates()
+    func checkForUpdatesInBackground()
+}
+
+@MainActor
+enum UpdateServiceFactory {
+    static func make() -> any UpdateService {
+        #if APP_STORE
+        return NoOpUpdateService()
+        #else
+        return SparkleUpdateService()
+        #endif
+    }
+}
+
+#if APP_STORE
+@MainActor
+/// App Store distributions receive updates through macOS rather than an in-app updater.
+private final class NoOpUpdateService: UpdateService {
+    var automaticallyChecksForUpdates: Bool {
+        get { false }
+        set {}
+    }
+
+    var sendsSystemProfile: Bool {
+        get { false }
+        set {}
+    }
+
+    let lastUpdateCheckDate: Date? = nil
+
+    func checkForUpdates() {}
+
+    func checkForUpdatesInBackground() {}
+}
+#else
+@MainActor
+private final class SparkleUpdateService: UpdateService {
+    private let controller: SPUStandardUpdaterController
+
+    init() {
+        self.controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
+
+    var automaticallyChecksForUpdates: Bool {
+        get { self.controller.updater.automaticallyChecksForUpdates }
+        set { self.controller.updater.automaticallyChecksForUpdates = newValue }
+    }
+
+    var sendsSystemProfile: Bool {
+        get { self.controller.updater.sendsSystemProfile }
+        set { self.controller.updater.sendsSystemProfile = newValue }
+    }
+
+    var lastUpdateCheckDate: Date? {
+        self.controller.updater.lastUpdateCheckDate
+    }
+
+    func checkForUpdates() {
+        self.controller.updater.checkForUpdates()
+    }
+
+    func checkForUpdatesInBackground() {
+        self.controller.updater.checkForUpdatesInBackground()
+    }
+}
+#endif

--- a/Apps/Keyty/Sources/Keyty/Support/Extensions/AppKit/NSWorkspace+AccessibilitySettings.swift
+++ b/Apps/Keyty/Sources/Keyty/Support/Extensions/AppKit/NSWorkspace+AccessibilitySettings.swift
@@ -1,0 +1,15 @@
+//
+//  NSWorkspace+AccessibilitySettings.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import AppKit
+
+extension NSWorkspace {
+    func openAccessibilitySettings() {
+        self.open(.accessibilitySettings)
+    }
+}

--- a/Apps/Keyty/Sources/Keyty/Support/Extensions/Foundation/URL+AccessibilitySettings.swift
+++ b/Apps/Keyty/Sources/Keyty/Support/Extensions/Foundation/URL+AccessibilitySettings.swift
@@ -1,0 +1,15 @@
+//
+//  URL+AccessibilitySettings.swift
+//  Keyty
+//
+//  SPDX-FileCopyrightText: 2026 Serhii Bykov
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+
+import Foundation
+
+extension URL {
+    static let accessibilitySettings = URL(
+        string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+    )!
+}

--- a/Apps/Keyty/Tests/KeytyTests/Features/PermissionsOnboarding/PermissionsOnboardingViewModelTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/PermissionsOnboarding/PermissionsOnboardingViewModelTests.swift
@@ -26,7 +26,7 @@ final class PermissionsOnboardingViewModelTests: XCTestCase {
         XCTAssertFalse(model.isComplete)
     }
 
-    func testRequestAccessibilityRequestsPermissionWithoutOpeningSettings() {
+    func testRequestAccessibilityForwardsAccessibilityRequest() {
         let service = TestPermissionsService()
         let model = PermissionsOnboardingViewModel(permissionsService: service)
 

--- a/Docs/BUILD.md
+++ b/Docs/BUILD.md
@@ -67,6 +67,25 @@ xcodebuild build \
   -configuration Release
 ```
 
+### App Store build
+
+The **Keyty AppStore** scheme uses the separate `AppStore` configuration and
+enables the App Sandbox. It is intentionally separate from `Release`, which
+continues to produce the Developer ID build for direct distribution.
+
+```bash
+cd Apps/Keyty
+tuist generate
+xcodebuild build \
+  -project Keyty.xcodeproj \
+  -scheme 'Keyty AppStore' \
+  -configuration AppStore
+```
+
+Use the App Store distribution option in Xcode Organizer to archive and upload
+an AppStore build once the App Store-specific feature and signing work is
+complete.
+
 ### Archive (for distribution)
 
 ```bash


### PR DESCRIPTION
## Summary

Add a separate sandboxed `Keyty AppStore` target and scheme for App Store builds. The direct-distribution `Keyty` target remains on the Developer ID release path.

This establishes the project and signing configuration only; App Store CI/CD and upload automation are intentionally out of scope.

## Included

- Add the `AppStore` build configuration and `Keyty AppStore` scheme.
- Add App Store-specific Info.plist and sandbox entitlements.
- Disable Sparkle and AppMover for App Store builds.
- Document local App Store builds.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`

## UI Changes

N/A

## Documentation

- [x] Updated `Docs/BUILD.md`

## Release Notes

N/A