### PR TITLE
fix(keyboard): collapse shortcuts while modifier is held

### DIFF
--- a/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
+++ b/Apps/Keyty/Sources/Keyty/Features/Visualizers/Keyboard/KeyboardVisualizer.swift
@@ -178,7 +178,7 @@ private extension KeyboardVisualizer {
             updateGroup: { group, items in self.visualizerWindow.updateGroup(group, with: items) }
         )
         self.collapseActiveRepeatIfNeeded(group)
-        if keystroke.type == .keyUp, keystroke.modifierFlags.intersection(Self.trackedModifierFlags).isEmpty {
+        if keystroke.type == .keyUp {
             self.finalizeGroupIfNeeded(group)
         }
     }

--- a/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
+++ b/Apps/Keyty/Tests/KeytyTests/Features/Visualizers/Keyboard/Keycaps/KeyboardVisualizerTests.swift
@@ -190,6 +190,34 @@ final class KeyboardVisualizerTests: XCTestCase {
         XCTAssertEqual(self.visualizer.visibleGroupCount, 1)
     }
 
+    func testCollapseRepeatedGroupsReusesChordWhileModifierRemainsPressed() {
+        self.settings.collapseRepeatedGroups = true
+        self.settings.onlyShowModifiedKeystrokes = true
+        self.visualizer.isPresentationActive = true
+
+        let command: NSEvent.ModifierFlags = .recorded([.command])
+        self.visualizer.display(.modifierStateChanged(command))
+
+        self.pressAndReleaseKey(.k, modifiers: command, character: "k")
+        self.pressAndReleaseKey(.k, modifiers: command, character: "k")
+
+        XCTAssertEqual(self.visualizer.visibleGroupCount, 1)
+    }
+
+    func testCollapseRepeatedGroupsEnforcesHistoryLimitWhileModifierRemainsPressed() {
+        self.settings.collapseRepeatedGroups = true
+        self.settings.onlyShowModifiedKeystrokes = true
+        self.visualizer.isPresentationActive = true
+
+        let command: NSEvent.ModifierFlags = .recorded([.command])
+        self.visualizer.display(.modifierStateChanged(command))
+
+        for (keyCode, character) in [(KeyboardKeyCode.a, "a"), (.k, "k"), (.a, "a"), (.k, "k")] {
+            self.pressAndReleaseKey(keyCode, modifiers: command, character: character)
+            XCTAssertEqual(self.visualizer.visibleGroupCount, 1)
+        }
+    }
+
     private func pressAndReleaseA() {
         self.visualizer.display(.keystroke(.stub(
             keyCode: .a,
@@ -222,5 +250,26 @@ final class KeyboardVisualizerTests: XCTestCase {
             charactersIgnoringModifiers: "k"
         )))
         self.visualizer.display(.modifierStateChanged([]))
+    }
+
+    private func pressAndReleaseKey(
+        _ keyCode: KeyboardKeyCode,
+        modifiers: NSEvent.ModifierFlags,
+        character: String
+    ) {
+        self.visualizer.display(.keystroke(.stub(
+            keyCode: keyCode,
+            type: .keyDown,
+            modifiers: modifiers,
+            characters: character,
+            charactersIgnoringModifiers: character
+        )))
+        self.visualizer.display(.keystroke(.stub(
+            keyCode: keyCode,
+            type: .keyUp,
+            modifiers: modifiers,
+            characters: character,
+            charactersIgnoringModifiers: character
+        )))
     }
 }


### PR DESCRIPTION
## Summary

Finalize each shortcut when its non-modifier key is released, so repeated shortcuts collapse and the history limit is enforced even while Command remains held.

Fixes #145. 

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS' -only-testing:KeytyTests/KeyboardVisualizerTests`

Run project commands from `Apps/Keyty`.

## UI Changes

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/74a4856e-4dd3-4eb1-b3b9-0b857380d3b9" /> | <video src="https://github.com/user-attachments/assets/7b65d584-8149-4ec4-8ff2-e17fe48e37a1" /> |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

Fixed shortcut history growing beyond its limit and repeated shortcuts not collapsing while a modifier key is held.