### PR TITLE
fix(build): configure App Store target signing and install settings

### DIFF
--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -60,9 +60,12 @@ let appReleaseSettings: SettingsDictionary = [
 // AppStore is the sandboxed build that will be archived for App Store Connect.
 let appStoreSettings: SettingsDictionary = [
     "CODE_SIGN_ENTITLEMENTS": "Sources/Keyty/Resources/AppStore.entitlements",
+    "CODE_SIGN_IDENTITY": "Apple Development",
     "CODE_SIGN_STYLE": "Automatic",
     "DEVELOPMENT_TEAM": "NEVA4MAZBL",
     "GCC_MODEL_TUNING": "G5",
+    "INFOPLIST_FILE": "Sources/Keyty/Resources/AppStore-Info.plist",
+    "INSTALL_PATH": "$(LOCAL_APPS_DIR)",
     "PRODUCT_BUNDLE_IDENTIFIER": "app.keyty.Keyty.AppStore",
     "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
         "$(inherited)",


### PR DESCRIPTION
## Summary

Configure the App Store target with the development signing identity, its dedicated Info.plist, and a local Applications install path.

## Tests

- [x] `tuist generate`
- [x] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination 'platform=macOS'`
- [x] Other: Not run (build-settings-only change)

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A