### PR TITLE
chore(release): bump version to 1.6.1

### DIFF
--- a/Apps/Keyty/Project.swift
+++ b/Apps/Keyty/Project.swift
@@ -12,7 +12,7 @@ let appSettings: SettingsDictionary = [
     "ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS": "YES",
     "CLANG_ENABLE_OBJC_WEAK": "YES",
     "CODE_SIGN_ENTITLEMENTS": "Sources/Keyty/Resources/Keyty.entitlements",
-    "CURRENT_PROJECT_VERSION": "160",
+    "CURRENT_PROJECT_VERSION": "161",
     "DEAD_CODE_STRIPPING": "YES",
     "ENABLE_HARDENED_RUNTIME": "YES",
     "FRAMEWORK_SEARCH_PATHS": [
@@ -28,7 +28,7 @@ let appSettings: SettingsDictionary = [
         "$(inherited)",
         "@executable_path/../Frameworks",
     ],
-    "MARKETING_VERSION": "1.6.0",
+    "MARKETING_VERSION": "1.6.1",
     "PRODUCT_BUNDLE_IDENTIFIER": "app.keyty.Keyty",
     "PRODUCT_NAME": "Keyty",
     "PROVISIONING_PROFILE_SPECIFIER": "",


### PR DESCRIPTION
## Summary

Bump the Keyty marketing version to 1.6.1 and the macOS build number to 161 for App Store upload.

## Tests

- [x] `tuist generate`
- [ ] `xcodebuild test -project Keyty.xcodeproj -scheme Keyty -destination "platform=macOS"`
- [ ] Other:

Run project commands from `Apps/Keyty`.

## UI Changes

N/A

| Before | After |
| --- | --- |
| N/A | N/A |

## Documentation

- [ ] Updated relevant docs
- [x] No docs needed

## Release Notes

N/A